### PR TITLE
Add SubTickScheduler for partial tick tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,18 @@ Additional Resources:
 ==========
 Community Documentation: https://docs.neoforged.net/  
 NeoForged Discord: https://discord.neoforged.net/
+
+Sub-Tick Scheduler
+------------------
+The library now exposes a small `SubTickScheduler` utility for running tasks at
+fractions of a Minecraft tick. This lets you schedule work with half or quarter
+ tick precision by delaying runnables using real time. Example:
+
+```java
+SubTickScheduler.scheduleHalfTick(() -> {
+    // code to execute ~25ms later
+});
+```
+
+Remember that scheduled tasks run on a separate thread; interact with the game
+only from the main thread.

--- a/src/main/java/com/thunder/ticktoklib/util/SubTickScheduler.java
+++ b/src/main/java/com/thunder/ticktoklib/util/SubTickScheduler.java
@@ -1,0 +1,63 @@
+package com.thunder.ticktoklib.util;
+
+import com.thunder.ticktoklib.TickTokHelper;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Simple scheduler for executing tasks at sub-tick precision.
+ * <p>
+ * This scheduler uses a single daemon thread to schedule runnables
+ * with millisecond delays corresponding to fractions of a Minecraft tick.
+ * It is intended for lightweight tasks that do not interact directly with
+ * the game world from the worker thread.
+ * </p>
+ */
+public class SubTickScheduler {
+    /**
+     * Number of sub-ticks per full tick. Quarter tick precision by default.
+     */
+    private static final int SUBTICKS_PER_TICK = 4;
+
+    /**
+     * Milliseconds in one sub-tick (50ms / 4 = 12.5ms).
+     */
+    private static final long SUBTICK_MS = TickTokHelper.MS_PER_TICK / SUBTICKS_PER_TICK;
+
+    private static final ScheduledExecutorService EXECUTOR = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "subtick-scheduler");
+        t.setDaemon(true);
+        return t;
+    });
+
+    /**
+     * Schedule a task after the specified delay in ticks. Fractions are allowed.
+     *
+     * @param tickDelay delay in ticks (may be fractional)
+     * @param task      runnable to execute
+     */
+    public static void schedule(double tickDelay, Runnable task) {
+        long delayMs = (long) Math.floor(tickDelay * TickTokHelper.MS_PER_TICK);
+        EXECUTOR.schedule(task, delayMs, TimeUnit.MILLISECONDS);
+    }
+
+    /** Schedule a task to run after half a tick (~25ms). */
+    public static void scheduleHalfTick(Runnable task) {
+        EXECUTOR.schedule(task, TickTokHelper.MS_PER_TICK / 2, TimeUnit.MILLISECONDS);
+    }
+
+    /** Schedule a task to run after a quarter tick (~12.5ms). */
+    public static void scheduleQuarterTick(Runnable task) {
+        EXECUTOR.schedule(task, SUBTICK_MS, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Shut down the scheduler. This should typically be called when the mod
+     * or game is stopping.
+     */
+    public static void shutdown() {
+        EXECUTOR.shutdownNow();
+    }
+}


### PR DESCRIPTION
## Summary
- add `SubTickScheduler` utility for scheduling half- and quarter-tick actions
- document new scheduler in README

## Testing
- `./gradlew build --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6885024a28a4832891cd23a481355f7a