### PR TITLE
Add server-thread scheduler API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,30 @@ SubTickScheduler.scheduleHalfTick(() -> {
 
 Remember that scheduled tasks run on a separate thread; interact with the game
 only from the main thread.
+
+To execute sub-tick tasks back on the server thread, you can pass a
+`MinecraftServer` instance:
+
+```java
+SubTickScheduler.scheduleOnServer(0.5, server, () -> {
+    // runs about half a tick later on the main thread
+});
+```
+
+Fast Water Flow Example
+----------------------
+Override the `getTickDelay` method in `WaterFluid` so flowing water updates
+every tick. This pairs well with scheduling partial updates using
+`SubTickScheduler`:
+
+```java
+@Mixin(WaterFluid.class)
+public abstract class WaterFluidMixin {
+    @Inject(method = "getTickDelay", at = @At("HEAD"), cancellable = true)
+    private void fastTicks(LevelReader level, CallbackInfoReturnable<Integer> cir) {
+        if (level instanceof Level world && !world.isClientSide()) {
+            cir.setReturnValue(1);
+        }
+    }
+}
+```

--- a/src/main/java/com/thunder/ticktoklib/util/SubTickScheduler.java
+++ b/src/main/java/com/thunder/ticktoklib/util/SubTickScheduler.java
@@ -1,6 +1,7 @@
 package com.thunder.ticktoklib.util;
 
 import com.thunder.ticktoklib.TickTokHelper;
+import net.minecraft.server.MinecraftServer;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -51,6 +52,28 @@ public class SubTickScheduler {
     /** Schedule a task to run after a quarter tick (~12.5ms). */
     public static void scheduleQuarterTick(Runnable task) {
         EXECUTOR.schedule(task, SUBTICK_MS, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Schedule a task to run on the server thread after the specified delay.
+     *
+     * @param tickDelay delay in ticks (may be fractional)
+     * @param server    MinecraftServer instance
+     * @param task      runnable to execute on the server thread
+     */
+    public static void scheduleOnServer(double tickDelay, MinecraftServer server, Runnable task) {
+        long delayMs = (long) Math.floor(tickDelay * TickTokHelper.MS_PER_TICK);
+        EXECUTOR.schedule(() -> server.execute(task), delayMs, TimeUnit.MILLISECONDS);
+    }
+
+    /** Schedule a half tick task on the server thread. */
+    public static void scheduleHalfTickOnServer(MinecraftServer server, Runnable task) {
+        EXECUTOR.schedule(() -> server.execute(task), TickTokHelper.MS_PER_TICK / 2, TimeUnit.MILLISECONDS);
+    }
+
+    /** Schedule a quarter tick task on the server thread. */
+    public static void scheduleQuarterTickOnServer(MinecraftServer server, Runnable task) {
+        EXECUTOR.schedule(() -> server.execute(task), SUBTICK_MS, TimeUnit.MILLISECONDS);
     }
 
     /**


### PR DESCRIPTION
## Summary
- extend `SubTickScheduler` with methods to execute tasks back on the server thread
- document scheduler usage and add a fast water flow mixin example

## Testing
- `./gradlew build` *(fails: toolchain requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_68850b5b39dc8328a8bdc9df9472a31c