### PR TITLE
Add debug logging across TickTok library classes

### DIFF
--- a/src/main/java/com/thunder/ticktoklib/Core/TickTok.java
+++ b/src/main/java/com/thunder/ticktoklib/Core/TickTok.java
@@ -27,20 +27,34 @@ public class TickTok {
      */
     public TickTok(IEventBus modEventBus, ModContainer container) {
 
+        ModConstants.LOGGER.info("Initializing TickTok core module");
+
         // Register mod setup and creative tabs
         modEventBus.addListener(this::commonSetup);
         modEventBus.addListener(this::addCreative);
 
+        if (ModConstants.LOGGER.isDebugEnabled()) {
+            ModConstants.LOGGER.debug("TickTok constructor - registered listeners for FMLCommonSetupEvent and BuildCreativeModeTabContentsEvent");
+        }
+
         // Register global events
         NeoForge.EVENT_BUS.register(this);
 
+        if (ModConstants.LOGGER.isDebugEnabled()) {
+            ModConstants.LOGGER.debug("TickTok constructor - subscribed to NeoForge.EVENT_BUS with {}", this.getClass().getSimpleName());
+        }
+
         container.registerConfig(ModConfig.Type.COMMON, TickTokConfig.SPEC);
+
+        if (ModConstants.LOGGER.isDebugEnabled()) {
+            ModConstants.LOGGER.debug("TickTok constructor - registered TickTokConfig.SPEC with ModConfig");
+        }
 
 
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {
-        event.enqueueWork(() -> System.out.println("Tick Tok Lib setup complete!"));
+        event.enqueueWork(() -> ModConstants.LOGGER.info("Tick Tok Lib setup complete via FMLCommonSetupEvent"));
     }
 
     private void addCreative(BuildCreativeModeTabContentsEvent event) {
@@ -55,7 +69,9 @@ public class TickTok {
      */
     @SubscribeEvent
     public void onServerStarting(ServerStartingEvent event) {
-
+        if (ModConstants.LOGGER.isDebugEnabled()) {
+            ModConstants.LOGGER.debug("TickTok.onServerStarting triggered for server {}", event.getServer().getServerVersion());
+        }
     }
 
     /**
@@ -65,5 +81,9 @@ public class TickTok {
      */
     @SubscribeEvent
     public void onRegisterCommands(RegisterCommandsEvent event) {
+        if (ModConstants.LOGGER.isTraceEnabled()) {
+            ModConstants.LOGGER.trace("TickTok.onRegisterCommands invoked - delegating to command registration (none configured)");
+        }
     }
 }
+

--- a/src/main/java/com/thunder/ticktoklib/TickTokFormatter.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokFormatter.java
@@ -1,15 +1,25 @@
 package com.thunder.ticktoklib;
 
+import com.thunder.ticktoklib.Core.ModConstants;
+
 import static com.thunder.ticktoklib.TickTokHelper.MS_PER_TICK;
 
 public class TickTokFormatter {
+
+    private static void logFormatting(String methodName, long ticks, String formatted) {
+        if (ModConstants.LOGGER.isDebugEnabled()) {
+            ModConstants.LOGGER.debug("TickTokFormatter.{}(ticks={}) -> {}", methodName, ticks, formatted);
+        }
+    }
 
     /** Format as "HH:mm" */
     public static String formatHHMM(long ticks) {
         int totalSeconds = (int)(ticks / TickTokHelper.TICKS_PER_SECOND);
         int hours   = totalSeconds / 3600;
         int minutes = (totalSeconds % 3600) / 60;
-        return String.format("%02d:%02d", hours, minutes);
+        String formatted = String.format("%02d:%02d", hours, minutes);
+        logFormatting("formatHHMM", ticks, formatted);
+        return formatted;
     }
 
     /** Format as "HH:mm:ss" */
@@ -18,7 +28,9 @@ public class TickTokFormatter {
         int hours   = totalSeconds / 3600;
         int minutes = (totalSeconds % 3600) / 60;
         int seconds = totalSeconds % 60;
-        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
+        String formatted = String.format("%02d:%02d:%02d", hours, minutes, seconds);
+        logFormatting("formatHHMMSS", ticks, formatted);
+        return formatted;
     }
 
     /** Format as "HH:mm:ss.SSS" */
@@ -28,6 +40,8 @@ public class TickTokFormatter {
         int minutes    = (totalMs % 3_600_000) / 60_000;
         int seconds    = (totalMs % 60_000) / 1000;
         int millis     = totalMs % 1000;
-        return String.format("%02d:%02d:%02d.%03d", hours, minutes, seconds, millis);
+        String formatted = String.format("%02d:%02d:%02d.%03d", hours, minutes, seconds, millis);
+        logFormatting("formatHMSms", ticks, formatted);
+        return formatted;
     }
 }

--- a/src/main/java/com/thunder/ticktoklib/TickTokHelper.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokHelper.java
@@ -1,5 +1,7 @@
 package com.thunder.ticktoklib;
 
+import com.thunder.ticktoklib.Core.ModConstants;
+
 /**
  * Core utility class for converting between Minecraft ticks and real-world time.
  */
@@ -10,43 +12,65 @@ public class TickTokHelper {
     public static final int TICKS_PER_HOUR     = TICKS_PER_MINUTE * 60;
     public static final int MS_PER_TICK        = 1000 / TICKS_PER_SECOND; // 50 ms per tick
 
+    private static void logConversion(String methodName, String input, Object result) {
+        if (ModConstants.LOGGER.isTraceEnabled()) {
+            ModConstants.LOGGER.trace("TickTokHelper.{}({}) -> {}", methodName, input, result);
+        }
+    }
+
     // Core conversions
     public static int toTicksSeconds(int seconds) {
-        return seconds * TICKS_PER_SECOND;
+        int ticks = seconds * TICKS_PER_SECOND;
+        logConversion("toTicksSeconds", "seconds=" + seconds, ticks);
+        return ticks;
     }
 
     public static int toTicksMinutes(int minutes) {
-        return minutes * TICKS_PER_MINUTE;
+        int ticks = minutes * TICKS_PER_MINUTE;
+        logConversion("toTicksMinutes", "minutes=" + minutes, ticks);
+        return ticks;
     }
 
     public static int toTicksHours(int hours) {
-        return hours * TICKS_PER_HOUR;
+        int ticks = hours * TICKS_PER_HOUR;
+        logConversion("toTicksHours", "hours=" + hours, ticks);
+        return ticks;
     }
 
     /**
      * Converts milliseconds to ticks, rounding to nearest tick.
      */
     public static int toTicksMilliseconds(int milliseconds) {
-        return Math.round(milliseconds * (TICKS_PER_SECOND / 1000f));
+        int ticks = Math.round(milliseconds * (TICKS_PER_SECOND / 1000f));
+        logConversion("toTicksMilliseconds", "milliseconds=" + milliseconds, ticks);
+        return ticks;
     }
 
     public static float toSeconds(int ticks) {
-        return ticks / (float) TICKS_PER_SECOND;
+        float seconds = ticks / (float) TICKS_PER_SECOND;
+        logConversion("toSeconds", "ticks=" + ticks, seconds);
+        return seconds;
     }
 
     public static float toMinutes(int ticks) {
-        return ticks / (float) TICKS_PER_MINUTE;
+        float minutes = ticks / (float) TICKS_PER_MINUTE;
+        logConversion("toMinutes", "ticks=" + ticks, minutes);
+        return minutes;
     }
 
     public static float toHours(int ticks) {
-        return ticks / (float) TICKS_PER_HOUR;
+        float hours = ticks / (float) TICKS_PER_HOUR;
+        logConversion("toHours", "ticks=" + ticks, hours);
+        return hours;
     }
 
     /**
      * Converts ticks back into total milliseconds.
      */
     public static int toMilliseconds(int ticks) {
-        return ticks * MS_PER_TICK;
+        int milliseconds = ticks * MS_PER_TICK;
+        logConversion("toMilliseconds", "ticks=" + ticks, milliseconds);
+        return milliseconds;
     }
 
     /**
@@ -62,7 +86,13 @@ public class TickTokHelper {
         int base =      hours   * TICKS_PER_HOUR
                 + minutes * TICKS_PER_MINUTE
                 + seconds * TICKS_PER_SECOND;
-        return base + toTicksMilliseconds(milliseconds);
+        int ticks = base + toTicksMilliseconds(milliseconds);
+        logConversion(
+                "duration",
+                String.format("h=%d, m=%d, s=%d, ms=%d", hours, minutes, seconds, milliseconds),
+                ticks
+        );
+        return ticks;
     }
 
     /**
@@ -71,6 +101,9 @@ public class TickTokHelper {
      * @return TickTokTimeBuilder
      */
     public static TickTokTimeBuilder time() {
+        if (ModConstants.LOGGER.isDebugEnabled()) {
+            ModConstants.LOGGER.debug("TickTokHelper.time() -> new TickTokTimeBuilder");
+        }
         return new TickTokTimeBuilder();
     }
 }

--- a/src/main/java/com/thunder/ticktoklib/TickTokTimeBuilder.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokTimeBuilder.java
@@ -1,5 +1,7 @@
 package com.thunder.ticktoklib;
 
+import com.thunder.ticktoklib.Core.ModConstants;
+
 public class TickTokTimeBuilder {
     private int hours        = 0;
     private int minutes      = 0;
@@ -26,6 +28,12 @@ public class TickTokTimeBuilder {
      * @return total ticks for the specified hours/minutes/seconds/milliseconds
      */
     public int toTicks() {
+        if (ModConstants.LOGGER.isDebugEnabled()) {
+            ModConstants.LOGGER.debug(
+                    "TickTokTimeBuilder.toTicks -> TickTokHelper.duration(h={}, m={}, s={}, ms={})",
+                    hours, minutes, seconds, milliseconds
+            );
+        }
         return TickTokHelper.duration(hours, minutes, seconds, milliseconds);
     }
 }

--- a/src/main/java/com/thunder/ticktoklib/api/TickTokAPI.java
+++ b/src/main/java/com/thunder/ticktoklib/api/TickTokAPI.java
@@ -1,6 +1,7 @@
 package com.thunder.ticktoklib.api;
 
 
+import com.thunder.ticktoklib.Core.ModConstants;
 import com.thunder.ticktoklib.TickTokFormatter;
 import com.thunder.ticktoklib.TickTokHelper;
 import com.thunder.ticktoklib.TickTokTimeBuilder;
@@ -10,30 +11,41 @@ import com.thunder.ticktoklib.TickTokTimeBuilder;
  */
 public class TickTokAPI {
 
+    private static void logDelegation(String methodName, String target, String details) {
+        if (ModConstants.LOGGER.isDebugEnabled()) {
+            ModConstants.LOGGER.debug("TickTokAPI.{} -> {} ({})", methodName, target, details);
+        }
+    }
+
     // ── Conversion from real‐world units to ticks ─────────────────────
 
     /** Convert seconds → ticks. */
     public static int toTicksFromSeconds(int seconds) {
+        logDelegation("toTicksFromSeconds", "TickTokHelper.toTicksSeconds", "seconds=" + seconds);
         return TickTokHelper.toTicksSeconds(seconds);
     }
 
     /** Convert minutes → ticks. */
     public static int toTicksFromMinutes(int minutes) {
+        logDelegation("toTicksFromMinutes", "TickTokHelper.toTicksMinutes", "minutes=" + minutes);
         return TickTokHelper.toTicksMinutes(minutes);
     }
 
     /** Convert hours → ticks. */
     public static int toTicksFromHours(int hours) {
+        logDelegation("toTicksFromHours", "TickTokHelper.toTicksHours", "hours=" + hours);
         return TickTokHelper.toTicksHours(hours);
     }
 
     /** Convert milliseconds → ticks (rounded). */
     public static int toTicksFromMilliseconds(int milliseconds) {
+        logDelegation("toTicksFromMilliseconds", "TickTokHelper.toTicksMilliseconds", "milliseconds=" + milliseconds);
         return TickTokHelper.toTicksMilliseconds(milliseconds);
     }
 
     /** Backwards‐compatible alias (assumes seconds). */
     public static int toTicks(int seconds) {
+        logDelegation("toTicks", "TickTokAPI.toTicksFromSeconds", "seconds=" + seconds);
         return toTicksFromSeconds(seconds);
     }
 
@@ -41,11 +53,13 @@ public class TickTokAPI {
 
     /** Build a complex duration (h, m, s, ms) fluently. */
     public static TickTokTimeBuilder timeBuilder() {
+        logDelegation("timeBuilder", "TickTokHelper.time", "constructing TickTokTimeBuilder");
         return TickTokHelper.time();
     }
 
     /** Full duration (h, m, s, ms) → ticks. */
     public static int duration(int hours, int minutes, int seconds, int milliseconds) {
+        logDelegation("duration", "TickTokHelper.duration", String.format("h=%d, m=%d, s=%d, ms=%d", hours, minutes, seconds, milliseconds));
         return TickTokHelper.duration(hours, minutes, seconds, milliseconds);
     }
 
@@ -53,21 +67,25 @@ public class TickTokAPI {
 
     /** Convert ticks → seconds (may be fractional). */
     public static float toSeconds(int ticks) {
+        logDelegation("toSeconds", "TickTokHelper.toSeconds", "ticks=" + ticks);
         return TickTokHelper.toSeconds(ticks);
     }
 
     /** Convert ticks → minutes. */
     public static float toMinutes(int ticks) {
+        logDelegation("toMinutes", "TickTokHelper.toMinutes", "ticks=" + ticks);
         return TickTokHelper.toMinutes(ticks);
     }
 
     /** Convert ticks → hours. */
     public static float toHours(int ticks) {
+        logDelegation("toHours", "TickTokHelper.toHours", "ticks=" + ticks);
         return TickTokHelper.toHours(ticks);
     }
 
     /** Convert ticks → total milliseconds. */
     public static int toMilliseconds(int ticks) {
+        logDelegation("toMilliseconds", "TickTokHelper.toMilliseconds", "ticks=" + ticks);
         return TickTokHelper.toMilliseconds(ticks);
     }
 
@@ -75,16 +93,19 @@ public class TickTokAPI {
 
     /** Format ticks as "HH:mm". */
     public static String formatHHMM(long ticks) {
+        logDelegation("formatHHMM", "TickTokFormatter.formatHHMM", "ticks=" + ticks);
         return TickTokFormatter.formatHHMM(ticks);
     }
 
     /** Format ticks as "HH:mm:ss". */
     public static String formatHHMMSS(long ticks) {
+        logDelegation("formatHHMMSS", "TickTokFormatter.formatHHMMSS", "ticks=" + ticks);
         return TickTokFormatter.formatHHMMSS(ticks);
     }
 
     /** Format ticks as "HH:mm:ss.SSS". */
     public static String formatHMSms(long ticks) {
+        logDelegation("formatHMSms", "TickTokFormatter.formatHMSms", "ticks=" + ticks);
         return TickTokFormatter.formatHMSms(ticks);
     }
 }

--- a/src/main/java/com/thunder/ticktoklib/client/TickTokClockRenderer.java
+++ b/src/main/java/com/thunder/ticktoklib/client/TickTokClockRenderer.java
@@ -1,5 +1,6 @@
 package com.thunder.ticktoklib.client;
 
+import com.thunder.ticktoklib.Core.ModConstants;
 import com.thunder.ticktoklib.TickTokConfig;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
@@ -30,11 +31,20 @@ public class TickTokClockRenderer {
 
         if (mc.player == null || mc.level == null) return;
 
+        if (ModConstants.LOGGER.isTraceEnabled()) {
+            ModConstants.LOGGER.trace("TickTokClockRenderer.onRender - player={}, level={}"
+                    , mc.player.getName().getString(), mc.level.dimension().location());
+        }
+
         ItemStack mainHand = mc.player.getMainHandItem();
         ItemStack offHand = mc.player.getOffhandItem();
 
         // Only show if holding a clock
         if (!mainHand.is(Items.CLOCK) && !offHand.is(Items.CLOCK)) return;
+
+        if (ModConstants.LOGGER.isDebugEnabled()) {
+            ModConstants.LOGGER.debug("TickTokClockRenderer.onRender - rendering HUD overlay using TickTokConfig settings");
+        }
 
         GuiGraphics graphics = event.getGuiGraphics();
         var font = mc.font;
@@ -51,11 +61,19 @@ public class TickTokClockRenderer {
             String gameTime = formatMinecraftTime(mc.level.getDayTime());
             graphics.drawString(font, "Game Time: " + gameTime, x, y, 0xFFFFFF, true);
             y += 12;
+
+            if (ModConstants.LOGGER.isTraceEnabled()) {
+                ModConstants.LOGGER.trace("TickTokClockRenderer - displayed game time via TickTokConfig.SHOW_GAME_TIME");
+            }
         }
 
         if (TickTokConfig.SHOW_LOCAL_TIME.get()) {
             String localTime = LocalTime.now().format(LOCAL_TIME_FORMAT);
             graphics.drawString(font, "Local Time: " + localTime, x, y, 0xAAAAFF, true);
+
+            if (ModConstants.LOGGER.isTraceEnabled()) {
+                ModConstants.LOGGER.trace("TickTokClockRenderer - displayed local time via TickTokConfig.SHOW_LOCAL_TIME");
+            }
         }
 
         graphics.pose().popPose();
@@ -68,3 +86,4 @@ public class TickTokClockRenderer {
         return String.format("%02d:%02d", hours, minutes);
     }
 }
+


### PR DESCRIPTION
## Summary
- add debug and trace logging to the TickTok API, helper, formatter, builder, renderer, and core entrypoint
- capture class usage information in log messages when conversions, formatting, and HUD rendering occur

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68f3041c9a3483289c7d13aeb2958d23