### PR TITLE
Remove TickTokAPI delegation logging deduplication

### DIFF
--- a/src/main/java/com/thunder/ticktoklib/api/TickTokAPI.java
+++ b/src/main/java/com/thunder/ticktoklib/api/TickTokAPI.java
@@ -5,22 +5,14 @@ import com.thunder.ticktoklib.Core.ModConstants;
 import com.thunder.ticktoklib.TickTokFormatter;
 import com.thunder.ticktoklib.TickTokHelper;
 import com.thunder.ticktoklib.TickTokTimeBuilder;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Public API façade for TickTokLib.
  */
 public class TickTokAPI {
-
-    private static final Set<String> LOGGED_DELEGATIONS = ConcurrentHashMap.newKeySet();
-
     private static void logDelegation(String methodName, String target, String details) {
         if (ModConstants.LOGGER.isDebugEnabled()) {
-            String key = methodName + "->" + target;
-            if (LOGGED_DELEGATIONS.add(key)) {
-                ModConstants.LOGGER.debug("TickTokAPI.{} -> {} ({})", methodName, target, details);
-            }
+            ModConstants.LOGGER.debug("TickTokAPI.{} -> {} ({})", methodName, target, details);
         }
     }
 


### PR DESCRIPTION
## Summary
- remove the delegation logging de-duplication logic from TickTokAPI so debug logs emit every call
- clean up the unused imports left from the removed tracking set

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68f57b8818708328b18a796e67d4859b