### PR TITLE
Add configurable toggle for debug logging

### DIFF
--- a/src/main/java/com/thunder/ticktoklib/Core/TickTok.java
+++ b/src/main/java/com/thunder/ticktoklib/Core/TickTok.java
@@ -33,20 +33,20 @@ public class TickTok {
         modEventBus.addListener(this::commonSetup);
         modEventBus.addListener(this::addCreative);
 
-        if (ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTok constructor - registered listeners for FMLCommonSetupEvent and BuildCreativeModeTabContentsEvent");
         }
 
         // Register global events
         NeoForge.EVENT_BUS.register(this);
 
-        if (ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTok constructor - subscribed to NeoForge.EVENT_BUS with {}", this.getClass().getSimpleName());
         }
 
         container.registerConfig(ModConfig.Type.COMMON, TickTokConfig.SPEC);
 
-        if (ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTok constructor - registered TickTokConfig.SPEC with ModConfig");
         }
 
@@ -69,7 +69,7 @@ public class TickTok {
      */
     @SubscribeEvent
     public void onServerStarting(ServerStartingEvent event) {
-        if (ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTok.onServerStarting triggered for server {}", event.getServer().getServerVersion());
         }
     }

--- a/src/main/java/com/thunder/ticktoklib/TickTokConfig.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokConfig.java
@@ -10,6 +10,7 @@ public class TickTokConfig {
     public static final ModConfigSpec.BooleanValue SHOW_LOCAL_TIME;
     public static final ModConfigSpec.ConfigValue<String> GAME_TIME_POSITION;
     public static final ModConfigSpec.ConfigValue<String> LOCAL_TIME_POSITION;
+    public static final ModConfigSpec.BooleanValue ENABLE_DEBUG_LOGGING;
 
     static {
         BUILDER.push("Tick Time Display Options");
@@ -29,6 +30,14 @@ public class TickTokConfig {
         LOCAL_TIME_POSITION = BUILDER
                 .comment("Local time position: top_left, top_right, bottom_left, bottom_right")
                 .define("local_time_position", "top_right");
+
+        BUILDER.pop();
+
+        BUILDER.push("Debugging");
+
+        ENABLE_DEBUG_LOGGING = BUILDER
+                .comment("Enable verbose debug-level logging output in the console")
+                .define("enable_debug_logging", false);
 
         BUILDER.pop();
         SPEC = BUILDER.build();

--- a/src/main/java/com/thunder/ticktoklib/TickTokFormatter.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokFormatter.java
@@ -1,13 +1,14 @@
 package com.thunder.ticktoklib;
 
 import com.thunder.ticktoklib.Core.ModConstants;
+import com.thunder.ticktoklib.TickTokConfig;
 
 import static com.thunder.ticktoklib.TickTokHelper.MS_PER_TICK;
 
 public class TickTokFormatter {
 
     private static void logFormatting(String methodName, long ticks, String formatted) {
-        if (ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTokFormatter.{}(ticks={}) -> {}", methodName, ticks, formatted);
         }
     }

--- a/src/main/java/com/thunder/ticktoklib/TickTokHelper.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokHelper.java
@@ -1,6 +1,7 @@
 package com.thunder.ticktoklib;
 
 import com.thunder.ticktoklib.Core.ModConstants;
+import com.thunder.ticktoklib.TickTokConfig;
 
 /**
  * Core utility class for converting between Minecraft ticks and real-world time.
@@ -101,7 +102,7 @@ public class TickTokHelper {
      * @return TickTokTimeBuilder
      */
     public static TickTokTimeBuilder time() {
-        if (ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTokHelper.time() -> new TickTokTimeBuilder");
         }
         return new TickTokTimeBuilder();

--- a/src/main/java/com/thunder/ticktoklib/TickTokTimeBuilder.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokTimeBuilder.java
@@ -1,6 +1,7 @@
 package com.thunder.ticktoklib;
 
 import com.thunder.ticktoklib.Core.ModConstants;
+import com.thunder.ticktoklib.TickTokConfig;
 
 public class TickTokTimeBuilder {
     private int hours        = 0;
@@ -28,7 +29,7 @@ public class TickTokTimeBuilder {
      * @return total ticks for the specified hours/minutes/seconds/milliseconds
      */
     public int toTicks() {
-        if (ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug(
                     "TickTokTimeBuilder.toTicks -> TickTokHelper.duration(h={}, m={}, s={}, ms={})",
                     hours, minutes, seconds, milliseconds

--- a/src/main/java/com/thunder/ticktoklib/api/TickTokAPI.java
+++ b/src/main/java/com/thunder/ticktoklib/api/TickTokAPI.java
@@ -2,6 +2,7 @@ package com.thunder.ticktoklib.api;
 
 
 import com.thunder.ticktoklib.Core.ModConstants;
+import com.thunder.ticktoklib.TickTokConfig;
 import com.thunder.ticktoklib.TickTokFormatter;
 import com.thunder.ticktoklib.TickTokHelper;
 import com.thunder.ticktoklib.TickTokTimeBuilder;
@@ -11,7 +12,7 @@ import com.thunder.ticktoklib.TickTokTimeBuilder;
  */
 public class TickTokAPI {
     private static void logDelegation(String methodName, String target, String details) {
-        if (ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTokAPI.{} -> {} ({})", methodName, target, details);
         }
     }

--- a/src/main/java/com/thunder/ticktoklib/client/TickTokClockRenderer.java
+++ b/src/main/java/com/thunder/ticktoklib/client/TickTokClockRenderer.java
@@ -42,7 +42,7 @@ public class TickTokClockRenderer {
         // Only show if holding a clock
         if (!mainHand.is(Items.CLOCK) && !offHand.is(Items.CLOCK)) return;
 
-        if (ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTokClockRenderer.onRender - rendering HUD overlay using TickTokConfig settings");
         }
 


### PR DESCRIPTION
## Summary
- add an `enable_debug_logging` option to the common configuration
- guard existing debug log statements behind the new toggle so they only fire when enabled

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68f58b31cca4832882947dc9a1567e04