### PR TITLE
Add safe accessors for TickTok config values

### DIFF
--- a/src/main/java/com/thunder/ticktoklib/Core/TickTok.java
+++ b/src/main/java/com/thunder/ticktoklib/Core/TickTok.java
@@ -33,20 +33,20 @@ public class TickTok {
         modEventBus.addListener(this::commonSetup);
         modEventBus.addListener(this::addCreative);
 
-        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.isDebugLoggingEnabled() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTok constructor - registered listeners for FMLCommonSetupEvent and BuildCreativeModeTabContentsEvent");
         }
 
         // Register global events
         NeoForge.EVENT_BUS.register(this);
 
-        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.isDebugLoggingEnabled() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTok constructor - subscribed to NeoForge.EVENT_BUS with {}", this.getClass().getSimpleName());
         }
 
         container.registerConfig(ModConfig.Type.COMMON, TickTokConfig.SPEC);
 
-        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.isDebugLoggingEnabled() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTok constructor - registered TickTokConfig.SPEC with ModConfig");
         }
 
@@ -69,7 +69,7 @@ public class TickTok {
      */
     @SubscribeEvent
     public void onServerStarting(ServerStartingEvent event) {
-        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.isDebugLoggingEnabled() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTok.onServerStarting triggered for server {}", event.getServer().getServerVersion());
         }
     }

--- a/src/main/java/com/thunder/ticktoklib/TickTokConfig.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokConfig.java
@@ -2,6 +2,8 @@ package com.thunder.ticktoklib;
 
 import net.neoforged.neoforge.common.ModConfigSpec;
 
+import java.util.function.Supplier;
+
 public class TickTokConfig {
     public static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
     public static final ModConfigSpec SPEC;
@@ -41,5 +43,41 @@ public class TickTokConfig {
 
         BUILDER.pop();
         SPEC = BUILDER.build();
+    }
+
+    private static <T> T safeGet(ModConfigSpec.ConfigValue<T> configValue, Supplier<T> fallbackSupplier) {
+        try {
+            return configValue.get();
+        } catch (IllegalStateException exception) {
+            return fallbackSupplier.get();
+        }
+    }
+
+    private static boolean safeGet(ModConfigSpec.BooleanValue configValue, boolean fallback) {
+        try {
+            return configValue.get();
+        } catch (IllegalStateException exception) {
+            return fallback;
+        }
+    }
+
+    public static boolean isDebugLoggingEnabled() {
+        return safeGet(ENABLE_DEBUG_LOGGING, false);
+    }
+
+    public static boolean showGameTime() {
+        return safeGet(SHOW_GAME_TIME, true);
+    }
+
+    public static boolean showLocalTime() {
+        return safeGet(SHOW_LOCAL_TIME, true);
+    }
+
+    public static String gameTimePosition() {
+        return safeGet(GAME_TIME_POSITION, () -> "top_left");
+    }
+
+    public static String localTimePosition() {
+        return safeGet(LOCAL_TIME_POSITION, () -> "top_right");
     }
 }

--- a/src/main/java/com/thunder/ticktoklib/TickTokFormatter.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokFormatter.java
@@ -8,7 +8,7 @@ import static com.thunder.ticktoklib.TickTokHelper.MS_PER_TICK;
 public class TickTokFormatter {
 
     private static void logFormatting(String methodName, long ticks, String formatted) {
-        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.isDebugLoggingEnabled() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTokFormatter.{}(ticks={}) -> {}", methodName, ticks, formatted);
         }
     }

--- a/src/main/java/com/thunder/ticktoklib/TickTokHelper.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokHelper.java
@@ -102,7 +102,7 @@ public class TickTokHelper {
      * @return TickTokTimeBuilder
      */
     public static TickTokTimeBuilder time() {
-        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.isDebugLoggingEnabled() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTokHelper.time() -> new TickTokTimeBuilder");
         }
         return new TickTokTimeBuilder();

--- a/src/main/java/com/thunder/ticktoklib/TickTokTimeBuilder.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokTimeBuilder.java
@@ -29,7 +29,7 @@ public class TickTokTimeBuilder {
      * @return total ticks for the specified hours/minutes/seconds/milliseconds
      */
     public int toTicks() {
-        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.isDebugLoggingEnabled() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug(
                     "TickTokTimeBuilder.toTicks -> TickTokHelper.duration(h={}, m={}, s={}, ms={})",
                     hours, minutes, seconds, milliseconds

--- a/src/main/java/com/thunder/ticktoklib/api/TickTokAPI.java
+++ b/src/main/java/com/thunder/ticktoklib/api/TickTokAPI.java
@@ -12,7 +12,7 @@ import com.thunder.ticktoklib.TickTokTimeBuilder;
  */
 public class TickTokAPI {
     private static void logDelegation(String methodName, String target, String details) {
-        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.isDebugLoggingEnabled() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTokAPI.{} -> {} ({})", methodName, target, details);
         }
     }

--- a/src/main/java/com/thunder/ticktoklib/client/TickTokClockRenderer.java
+++ b/src/main/java/com/thunder/ticktoklib/client/TickTokClockRenderer.java
@@ -42,7 +42,7 @@ public class TickTokClockRenderer {
         // Only show if holding a clock
         if (!mainHand.is(Items.CLOCK) && !offHand.is(Items.CLOCK)) return;
 
-        if (TickTokConfig.ENABLE_DEBUG_LOGGING.get() && ModConstants.LOGGER.isDebugEnabled()) {
+        if (TickTokConfig.isDebugLoggingEnabled() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTokClockRenderer.onRender - rendering HUD overlay using TickTokConfig settings");
         }
 
@@ -57,7 +57,7 @@ public class TickTokClockRenderer {
         graphics.pose().pushPose();
         graphics.pose().translate(0, 0, 1000); // Ensure it's drawn above everything
 
-        if (TickTokConfig.SHOW_GAME_TIME.get()) {
+        if (TickTokConfig.showGameTime()) {
             String gameTime = formatMinecraftTime(mc.level.getDayTime());
             graphics.drawString(font, "Game Time: " + gameTime, x, y, 0xFFFFFF, true);
             y += 12;
@@ -67,7 +67,7 @@ public class TickTokClockRenderer {
             }
         }
 
-        if (TickTokConfig.SHOW_LOCAL_TIME.get()) {
+        if (TickTokConfig.showLocalTime()) {
             String localTime = LocalTime.now().format(LOCAL_TIME_FORMAT);
             graphics.drawString(font, "Local Time: " + localTime, x, y, 0xAAAAFF, true);
 


### PR DESCRIPTION
## Summary
- add safe getters to `TickTokConfig` that fall back to defaults until the config spec is loaded
- update logging and HUD logic to use the safe helpers instead of accessing config values directly

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68f58f0f25708328b42a454f03e1dfa4