### PR TITLE
Add scheduling utilities and command formatting helpers

### DIFF
--- a/src/main/java/com/thunder/ticktoklib/Core/TickTok.java
+++ b/src/main/java/com/thunder/ticktoklib/Core/TickTok.java
@@ -4,11 +4,9 @@ import com.mojang.brigadier.arguments.LongArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.thunder.ticktoklib.TickTokConfig;
 import com.thunder.ticktoklib.api.TickTokAPI;
-import com.thunder.ticktoklib.api.TickTokPhase;
 import com.thunder.ticktoklib.util.TickTokPhaseTracker;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
-import net.minecraft.network.chat.Component;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModContainer;
@@ -99,16 +97,14 @@ public class TickTok {
                 .then(Commands.literal("now")
                         .executes(ctx -> {
                             long dayTime = ctx.getSource().getLevel().getDayTime();
-                            TickTokPhase phase = TickTokAPI.currentPhase(dayTime);
-                            ctx.getSource().sendSuccess(() -> Component.literal(String.format("Day time: %d (%s)", dayTime, phase)), true);
+                            ctx.getSource().sendSuccess(() -> TickTokAPI.buildPhaseReport(dayTime), true);
                             return 1;
                         }))
                 .then(Commands.literal("convert")
                         .then(Commands.argument("ticks", LongArgumentType.longArg(0))
                                 .executes(ctx -> {
                                     long ticks = LongArgumentType.getLong(ctx, "ticks");
-                                    String formatted = TickTokAPI.formatHHMMSS(ticks);
-                                    ctx.getSource().sendSuccess(() -> Component.literal(String.format("%d ticks -> %s (%.2f seconds)", ticks, formatted, TickTokAPI.toSeconds((int) ticks))), false);
+                                    ctx.getSource().sendSuccess(() -> TickTokAPI.buildConversionReport(ticks), false);
                                     return 1;
                                 })));
 

--- a/src/main/java/com/thunder/ticktoklib/event/TickTokPhaseEvent.java
+++ b/src/main/java/com/thunder/ticktoklib/event/TickTokPhaseEvent.java
@@ -1,22 +1,26 @@
 package com.thunder.ticktoklib.event;
 
 import com.thunder.ticktoklib.api.TickTokPhase;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
 import net.neoforged.bus.api.Event;
 
 public abstract class TickTokPhaseEvent extends Event {
     public final TickTokPhase phase;
     public final long dayTime;
+    public final ResourceKey<Level> levelKey;
 
-    public TickTokPhaseEvent(TickTokPhase phase, long dayTime) {
+    public TickTokPhaseEvent(TickTokPhase phase, long dayTime, ResourceKey<Level> levelKey) {
         this.phase = phase;
         this.dayTime = dayTime;
+        this.levelKey = levelKey;
     }
 
     public static class Start extends TickTokPhaseEvent {
-        public Start(TickTokPhase phase, long dayTime) { super(phase, dayTime); }
+        public Start(TickTokPhase phase, long dayTime, ResourceKey<Level> levelKey) { super(phase, dayTime, levelKey); }
     }
 
     public static class End extends TickTokPhaseEvent {
-        public End(TickTokPhase phase, long dayTime) { super(phase, dayTime); }
+        public End(TickTokPhase phase, long dayTime, ResourceKey<Level> levelKey) { super(phase, dayTime, levelKey); }
     }
 }

--- a/src/main/java/com/thunder/ticktoklib/util/TickTokPhaseScheduler.java
+++ b/src/main/java/com/thunder/ticktoklib/util/TickTokPhaseScheduler.java
@@ -1,0 +1,112 @@
+package com.thunder.ticktoklib.util;
+
+import com.thunder.ticktoklib.Core.ModConstants;
+import com.thunder.ticktoklib.TickTokConfig;
+import com.thunder.ticktoklib.api.TickTokPhase;
+import com.thunder.ticktoklib.event.TickTokPhaseEvent;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.common.NeoForge;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Allows callers to schedule callbacks that fire when a specific phase begins.
+ */
+public class TickTokPhaseScheduler {
+    private final Map<ResourceKey<Level>, Map<TickTokPhase, List<Runnable>>> scheduled = new ConcurrentHashMap<>();
+    private final Map<TickTokPhase, List<Runnable>> anyLevelScheduled = new EnumMap<>(TickTokPhase.class);
+
+    public TickTokPhaseScheduler() {
+        NeoForge.EVENT_BUS.register(this);
+    }
+
+    /**
+     * Schedule a task that runs when the next occurrence of the phase begins on any level.
+     */
+    public void scheduleAtPhase(TickTokPhase phase, Runnable task) {
+        scheduleAtPhaseInternal(null, phase, task);
+    }
+
+    /**
+     * Schedule a task that runs when the next occurrence of the phase begins in a specific level.
+     */
+    public void scheduleAtPhase(ResourceKey<Level> levelKey, TickTokPhase phase, Runnable task) {
+        Objects.requireNonNull(levelKey, "levelKey");
+        scheduleAtPhaseInternal(levelKey, phase, task);
+    }
+
+    /**
+     * Create a barrier that completes when the target phase starts on the given level (or any level if null).
+     */
+    public PhaseBarrier barrier(ResourceKey<Level> levelKey, TickTokPhase phase) {
+        CompletableFuture<Void> gate = new CompletableFuture<>();
+        scheduleAtPhaseInternal(levelKey, phase, () -> gate.complete(null));
+        return new PhaseBarrier(gate);
+    }
+
+    @SubscribeEvent
+    public void onPhaseStart(TickTokPhaseEvent.Start event) {
+        fireFor(event.levelKey, event.phase);
+        fireFor(null, event.phase);
+    }
+
+    private void fireFor(ResourceKey<Level> levelKey, TickTokPhase phase) {
+        Map<TickTokPhase, List<Runnable>> perPhase = levelKey == null ? anyLevelScheduled : scheduled.get(levelKey);
+        if (perPhase == null) {
+            return;
+        }
+
+        List<Runnable> tasks = perPhase.get(phase);
+        if (tasks == null || tasks.isEmpty()) {
+            return;
+        }
+
+        if (TickTokConfig.isEventTracingEnabled() && ModConstants.LOGGER.isTraceEnabled()) {
+            ModConstants.LOGGER.trace("TickTokPhaseScheduler firing {} task(s) for {} in {}", tasks.size(), phase, levelKey == null ? "any level" : levelKey.location());
+        }
+
+        // Run tasks and clear one-shot schedule
+        Iterator<Runnable> iterator = tasks.iterator();
+        while (iterator.hasNext()) {
+            Runnable runnable = iterator.next();
+            iterator.remove();
+            runnable.run();
+        }
+    }
+
+    private void scheduleAtPhaseInternal(ResourceKey<Level> levelKey, TickTokPhase phase, Runnable task) {
+        Objects.requireNonNull(phase, "phase");
+        Objects.requireNonNull(task, "task");
+        Map<TickTokPhase, List<Runnable>> perPhase = levelKey == null
+                ? anyLevelScheduled
+                : scheduled.computeIfAbsent(levelKey, key -> new EnumMap<>(TickTokPhase.class));
+
+        perPhase
+                .computeIfAbsent(phase, __ -> new ArrayList<>())
+                .add(task);
+
+        if (TickTokConfig.isDebugLoggingEnabled() && ModConstants.LOGGER.isDebugEnabled()) {
+            ModConstants.LOGGER.debug("TickTokPhaseScheduler scheduled task for phase {} in {}", phase, Optional.ofNullable(levelKey).map(key -> key.location().toString()).orElse(ModConstants.MOD_ID + ":any"));
+        }
+    }
+
+    public record PhaseBarrier(CompletableFuture<Void> gate) {
+        public CompletableFuture<Void> asFuture() {
+            return gate;
+        }
+
+        public boolean cancel() {
+            return gate.cancel(false);
+        }
+    }
+}

--- a/src/main/java/com/thunder/ticktoklib/util/TickTokPhaseTracker.java
+++ b/src/main/java/com/thunder/ticktoklib/util/TickTokPhaseTracker.java
@@ -24,13 +24,13 @@ public class TickTokPhaseTracker {
             if (TickTokConfig.isEventTracingEnabled() && ModConstants.LOGGER.isTraceEnabled()) {
                 ModConstants.LOGGER.trace("TickTokPhaseTracker initialized phase {} for {}", current, levelKey.location());
             }
-            NeoForge.EVENT_BUS.post(new TickTokPhaseEvent.Start(current, clamped));
+            NeoForge.EVENT_BUS.post(new TickTokPhaseEvent.Start(current, clamped, levelKey));
             return;
         }
 
         if (last != current) {
-            NeoForge.EVENT_BUS.post(new TickTokPhaseEvent.End(last, clamped));
-            NeoForge.EVENT_BUS.post(new TickTokPhaseEvent.Start(current, clamped));
+            NeoForge.EVENT_BUS.post(new TickTokPhaseEvent.End(last, clamped, levelKey));
+            NeoForge.EVENT_BUS.post(new TickTokPhaseEvent.Start(current, clamped, levelKey));
             lastPhaseByLevel.put(levelKey, current);
             if (TickTokConfig.isEventTracingEnabled() && ModConstants.LOGGER.isTraceEnabled()) {
                 ModConstants.LOGGER.trace("TickTokPhaseTracker transitioned {} -> {} for {} at {}", last, current, levelKey.location(), clamped);

--- a/src/main/java/com/thunder/ticktoklib/util/TickTokTimeUtils.java
+++ b/src/main/java/com/thunder/ticktoklib/util/TickTokTimeUtils.java
@@ -1,0 +1,87 @@
+package com.thunder.ticktoklib.util;
+
+import com.thunder.ticktoklib.Core.ModConstants;
+import com.thunder.ticktoklib.TickTokConfig;
+import com.thunder.ticktoklib.TickTokHelper;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.Level;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utility helpers that bridge Java time primitives with tick-based time in Minecraft.
+ */
+public final class TickTokTimeUtils {
+    private TickTokTimeUtils() {
+    }
+
+    /** Convert ticks to a {@link Duration}. */
+    public static Duration ticksToDuration(long ticks) {
+        long millis = TickTokHelper.toMillisecondsLong(ticks);
+        debug("ticksToDuration", "ticks=" + ticks + " -> " + millis + "ms");
+        return Duration.ofMillis(millis);
+    }
+
+    /** Convert ticks to a {@link Duration}, retaining the level for future time-scaling hooks. */
+    public static Duration ticksToDuration(Level level, long ticks) {
+        Objects.requireNonNull(level, "level");
+        return ticksToDuration(ticks);
+    }
+
+    /** Convert a {@link Duration} to ticks (rounded). */
+    public static long durationToTicks(Duration duration) {
+        Objects.requireNonNull(duration, "duration");
+        long millis = duration.toMillis();
+        long ticks = TickTokHelper.toTicksMilliseconds(millis);
+        debug("durationToTicks", "duration=" + millis + "ms -> " + ticks + "t");
+        return ticks;
+    }
+
+    /** Convert a {@link TimeUnit}-based duration to ticks. */
+    public static long timeUnitToTicks(long time, TimeUnit unit) {
+        Objects.requireNonNull(unit, "unit");
+        long millis = unit.toMillis(time);
+        long ticks = TickTokHelper.toTicksMilliseconds(millis);
+        debug("timeUnitToTicks", "time=" + time + " " + unit + " -> " + ticks + "t");
+        return ticks;
+    }
+
+    /** Convert ticks to the requested {@link TimeUnit}. */
+    public static long ticksToTimeUnit(long ticks, TimeUnit unit) {
+        Objects.requireNonNull(unit, "unit");
+        long millis = TickTokHelper.toMillisecondsLong(ticks);
+        long converted = unit.convert(millis, TimeUnit.MILLISECONDS);
+        debug("ticksToTimeUnit", "ticks=" + ticks + " -> " + converted + " " + unit);
+        return converted;
+    }
+
+    /**
+     * Schedule a task to run after the given number of ticks using the common pool. This is best-effort and not a
+     * replacement for server-thread scheduling; callers should hop back to the main thread as needed.
+     */
+    public static CompletableFuture<Void> sleepTicksAsync(long ticks) {
+        Duration delay = ticksToDuration(ticks);
+        debug("sleepTicksAsync", "ticks=" + ticks + ", delay=" + delay);
+        return CompletableFuture.runAsync(() -> {
+        }, CompletableFuture.delayedExecutor(delay.toMillis(), TimeUnit.MILLISECONDS));
+    }
+
+    /**
+     * Schedule a task to run after the given ticks relative to a server instance. The task itself is run on the main
+     * thread using {@link MinecraftServer#execute(Runnable)}.
+     */
+    public static CompletableFuture<Void> sleepTicksOnServer(MinecraftServer server, long ticks, Runnable task) {
+        Objects.requireNonNull(server, "server");
+        Objects.requireNonNull(task, "task");
+        return sleepTicksAsync(ticks).thenRun(() -> server.execute(task));
+    }
+
+    private static void debug(String method, String message) {
+        if (TickTokConfig.isDebugLoggingEnabled() && ModConstants.LOGGER.isDebugEnabled()) {
+            ModConstants.LOGGER.debug("TickTokTimeUtils.{} -> {}", method, message);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add tick and duration bridging utilities, including async sleep helpers
- introduce phase scheduler/barrier API and include level context on phase events
- expose reusable command-style formatting helpers for tick conversions

## Testing
- ./gradlew test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949e12dcab083289621affa04d4da44)