### PR TITLE
Rewrite tick lag warning in console

### DIFF
--- a/src/main/java/com/thunder/ticktoklib/TickTokLagFormatter.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokLagFormatter.java
@@ -1,0 +1,43 @@
+package com.thunder.ticktoklib;
+
+import com.thunder.ticktoklib.Core.ModConstants;
+import net.minecraft.network.chat.Component;
+
+/**
+ * Helpers for turning "server is X ticks behind" messages into human-friendly time.
+ */
+public class TickTokLagFormatter {
+
+    private TickTokLagFormatter() {
+    }
+
+    public static String formatLagBehind(long ticksBehind, long millisecondsBehind) {
+        double seconds = ticksBehind / (double) TickTokHelper.TICKS_PER_SECOND;
+        String formatted = String.format(
+                "Server is %d ticks behind (%.2f seconds / %d ms)",
+                ticksBehind,
+                seconds,
+                millisecondsBehind
+        );
+        logFormatting("formatLagBehind", ticksBehind, formatted);
+        return formatted;
+    }
+
+    /**
+     * Format a lagging tick count into a chat-friendly {@link Component}.
+     *
+     * @param ticksBehind how many ticks the server is behind
+     * @return formatted component, e.g. {@code "Server is 120 ticks behind (6.00 seconds / 6000 ms)"}
+     */
+    public static Component buildLagBehindReport(long ticksBehind) {
+        String formatted = formatLagBehind(ticksBehind, TickTokHelper.toMillisecondsLong(ticksBehind));
+        logFormatting("buildLagBehindReport", ticksBehind, formatted);
+        return Component.literal(formatted);
+    }
+
+    private static void logFormatting(String methodName, long ticks, String formatted) {
+        if (TickTokConfig.isConversionTracingEnabled() && ModConstants.LOGGER.isTraceEnabled()) {
+            ModConstants.LOGGER.trace("TickTokLagFormatter.{}(ticks={}) -> {}", methodName, ticks, formatted);
+        }
+    }
+}

--- a/src/main/java/com/thunder/ticktoklib/api/TickTokAPI.java
+++ b/src/main/java/com/thunder/ticktoklib/api/TickTokAPI.java
@@ -267,4 +267,9 @@ public class TickTokAPI {
         float seconds = TickTokHelper.toSeconds((int) ticks);
         return net.minecraft.network.chat.Component.literal(String.format("%d ticks -> %s (%.2f seconds)", ticks, formatted, seconds));
     }
+
+    public static net.minecraft.network.chat.Component buildLagBehindReport(long ticksBehind) {
+        logDelegation("buildLagBehindReport", "TickTokLagFormatter.buildLagBehindReport", "ticksBehind=" + ticksBehind);
+        return com.thunder.ticktoklib.TickTokLagFormatter.buildLagBehindReport(ticksBehind);
+    }
 }

--- a/src/main/java/com/thunder/ticktoklib/mixin/MinecraftServerMixin.java
+++ b/src/main/java/com/thunder/ticktoklib/mixin/MinecraftServerMixin.java
@@ -1,0 +1,29 @@
+package com.thunder.ticktoklib.mixin;
+
+import com.thunder.ticktoklib.TickTokLagFormatter;
+import net.minecraft.server.MinecraftServer;
+import org.slf4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(MinecraftServer.class)
+public abstract class MinecraftServerMixin {
+
+    private static final String BEHIND_PATTERN = "Can't keep up! Is the server overloaded? Running {}ms or {} ticks behind";
+
+    @Redirect(
+            method = "tickServer",
+            at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;warn(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V")
+    )
+    private void ticktoklib$rewriteLagWarning(Logger logger, String pattern, Object millisBehindObj, Object ticksBehindObj) {
+        if (BEHIND_PATTERN.equals(pattern)) {
+            long ticksBehind = ((Number) ticksBehindObj).longValue();
+            long millisBehind = ((Number) millisBehindObj).longValue();
+            logger.warn(TickTokLagFormatter.formatLagBehind(ticksBehind, millisBehind));
+            return;
+        }
+
+        logger.warn(pattern, millisBehindObj, ticksBehindObj);
+    }
+}

--- a/src/main/resources/ticktoklib.mixins.json
+++ b/src/main/resources/ticktoklib.mixins.json
@@ -1,0 +1,12 @@
+{
+  "required": false,
+  "minVersion": "0.8",
+  "package": "com.thunder.ticktoklib.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": [
+    "MinecraftServerMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -48,8 +48,8 @@ authors="${mod_authors}" #optional
 description='''${mod_description}'''
 
 # The [[mixins]] block allows you to declare your mixin config to FML so that it gets loaded.
-#[[mixins]]
-#config="${mod_id}.mixins.json"
+[[mixins]]
+config="ticktoklib.mixins.json"
 
 # The [[accessTransformers]] block allows you to declare where your AT file is.
 # If this block is omitted, a fallback attempt will be made to load an AT from META-INF/accesstransformer.cfg


### PR DESCRIPTION
## Summary
- add TickTokLagFormatter to format "server is X ticks behind" messages into human-readable time
- expose buildLagBehindReport through the API for easy component creation
- override the default server lag warning with a mixin to log the formatted message in the console

## Testing
- ./gradlew test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ebe90ab788328a09c03cb28267677)