### PR TITLE
Optimize HUD caching and scheduler cleanup

### DIFF
--- a/src/main/java/com/thunder/ticktoklib/client/TickTokClockRenderer.java
+++ b/src/main/java/com/thunder/ticktoklib/client/TickTokClockRenderer.java
@@ -14,6 +14,7 @@ import net.neoforged.neoforge.client.event.RenderGuiEvent;
 
 import java.time.LocalTime;
 import java.util.Locale;
+import java.util.Objects;
 
 import static com.thunder.ticktoklib.Core.ModConstants.MOD_ID;
 
@@ -22,6 +23,14 @@ import static com.thunder.ticktoklib.Core.ModConstants.MOD_ID;
         */
 @EventBusSubscriber(modid = MOD_ID, value = Dist.CLIENT)
 public class TickTokClockRenderer {
+
+    private static final Locale LOCALE = Locale.getDefault();
+    private static final java.time.format.DateTimeFormatter LOCAL_TIME_FORMATTER = java.time.format.DateTimeFormatter.ofPattern("HH:mm:ss");
+
+    private static String cachedGameTime;
+    private static String cachedLocalTime;
+    private static long lastGameTick = Long.MIN_VALUE;
+    private static long lastLocalSecond = Long.MIN_VALUE;
 
     @SubscribeEvent
     public static void onRender(RenderGuiEvent.Post event) {
@@ -34,11 +43,12 @@ public class TickTokClockRenderer {
                     mc.player.getName().getString(), mc.level.dimension().location());
         }
 
-        ItemStack mainHand = mc.player.getMainHandItem();
-        ItemStack offHand = mc.player.getOffhandItem();
-
         // Only show if holding a clock
-        if (!mainHand.is(Items.CLOCK) && !offHand.is(Items.CLOCK)) return;
+        if (!isHoldingClock(mc)) return;
+
+        // Ensure caches are populated once per frame; updates only happen when values change.
+        updateGameTimeCache(mc);
+        updateLocalTimeCache();
 
         if (TickTokConfig.isDebugLoggingEnabled() && ModConstants.LOGGER.isDebugEnabled()) {
             ModConstants.LOGGER.debug("TickTokClockRenderer.onRender - rendering HUD overlay using TickTokConfig settings");
@@ -54,9 +64,7 @@ public class TickTokClockRenderer {
         graphics.pose().translate(0, 0, 1000); // Ensure it's drawn above everything
 
         if (TickTokConfig.showGameTime()) {
-            long dayTime = Math.floorMod(mc.level.getDayTime(), 24000L);
-            String gameTime = TickTokFormatter.formatClock(dayTime, true, false, true, Locale.getDefault());
-            String text = "Game Time: " + gameTime;
+            String text = "Game Time: " + Objects.requireNonNullElse(cachedGameTime, "--:--:--");
             graphics.drawString(font, text, x, y, 0xFFFFFF, true);
             y += font.lineHeight + 2;
 
@@ -66,8 +74,7 @@ public class TickTokClockRenderer {
         }
 
         if (TickTokConfig.showLocalTime()) {
-            String localTime = LocalTime.now().format(java.time.format.DateTimeFormatter.ofPattern("HH:mm:ss"));
-            String text = "Local Time: " + localTime;
+            String text = "Local Time: " + Objects.requireNonNullElse(cachedLocalTime, "--:--:--");
             graphics.drawString(font, text, x, y, 0xAAAAFF, true);
 
             if (ModConstants.LOGGER.isTraceEnabled()) {
@@ -76,5 +83,35 @@ public class TickTokClockRenderer {
         }
 
         graphics.pose().popPose();
+    }
+
+    private static boolean isHoldingClock(Minecraft mc) {
+        ItemStack mainHand = mc.player.getMainHandItem();
+        ItemStack offHand = mc.player.getOffhandItem();
+        return mainHand.is(Items.CLOCK) || offHand.is(Items.CLOCK);
+    }
+
+    private static void updateGameTimeCache(Minecraft mc) {
+        if (!TickTokConfig.showGameTime()) {
+            return;
+        }
+
+        long dayTime = Math.floorMod(mc.level.getDayTime(), 24000L);
+        if (dayTime != lastGameTick) {
+            cachedGameTime = TickTokFormatter.formatClock(dayTime, true, false, true, LOCALE);
+            lastGameTick = dayTime;
+        }
+    }
+
+    private static void updateLocalTimeCache() {
+        if (!TickTokConfig.showLocalTime()) {
+            return;
+        }
+
+        long currentSecond = System.currentTimeMillis() / 1000L;
+        if (currentSecond != lastLocalSecond) {
+            cachedLocalTime = LocalTime.now().format(LOCAL_TIME_FORMATTER);
+            lastLocalSecond = currentSecond;
+        }
     }
 }

--- a/src/main/java/com/thunder/ticktoklib/util/TickTokPhaseScheduler.java
+++ b/src/main/java/com/thunder/ticktoklib/util/TickTokPhaseScheduler.java
@@ -82,6 +82,14 @@ public class TickTokPhaseScheduler {
             iterator.remove();
             runnable.run();
         }
+
+        if (tasks.isEmpty()) {
+            perPhase.remove(phase);
+
+            if (perPhase.isEmpty() && levelKey != null) {
+                scheduled.remove(levelKey);
+            }
+        }
     }
 
     private void scheduleAtPhaseInternal(ResourceKey<Level> levelKey, TickTokPhase phase, Runnable task) {


### PR DESCRIPTION
## Summary
- cache formatted game and local time strings to avoid per-frame allocations and computations
- reuse static formatters and only refresh values when ticks or seconds change
- clear empty task lists/maps in the phase scheduler after firing to prevent buildup

## Testing
- ./gradlew test -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee55104c88328b98242933fa80503)