### PR TITLE
Add changelog for 1.4.1

### DIFF
--- a/changelogs/CHANGELOG1.4.1.md
+++ b/changelogs/CHANGELOG1.4.1.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [Released]
+### Highlights
+- Added Java-time helpers (`ticksToDuration`, `durationToTicks`, `timeUnitToTicks`, `sleepTicksAsync`, `sleepTicksOnServer`) so mods can bridge TickTok timings with `Duration`, `TimeUnit`, and async scheduling via the public API.  
+- Introduced phase scheduling utilities (`scheduleAtPhase`, level-aware scheduling, and `phaseBarrier`) to run callbacks precisely when dawn/day/dusk/night begin.  
+- Reworked the server's "Can't keep up" warning to report ticks, seconds, and milliseconds behind using TickTok's lag formatter for clearer diagnostics.  
+- Optimized the HUD clock overlay by caching formatted game/local time once per tick/second and skipping redundant renders when the player isn't holding a clock.  
+- Bundled a logo in the mod metadata so TickTokLib displays with branding in the NeoForge mod list.  


### PR DESCRIPTION
## Summary
- add a user-facing changelog for version 1.4.1 covering new scheduling/time utilities, lag warning messaging, HUD caching tweaks, and the bundled logo

## Testing
- Not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ee7a4e26c8328846dd60d8ade084a)