### PR TITLE
Improve tick/ms conversions, fix formatter tracing, and add SubTickScheduler utility

### DIFF
--- a/src/main/java/com/thunder/ticktoklib/TickTokFormatter.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokFormatter.java
@@ -19,9 +19,9 @@ public class TickTokFormatter {
 
     /** Format as "HH:mm" */
     public static String formatHHMM(long ticks) {
-        int totalSeconds = (int)(ticks / TickTokHelper.TICKS_PER_SECOND);
-        int hours   = totalSeconds / 3600;
-        int minutes = (totalSeconds % 3600) / 60;
+        long totalSeconds = ticks / TickTokHelper.TICKS_PER_SECOND;
+        long hours   = totalSeconds / 3600;
+        long minutes = (totalSeconds % 3600) / 60;
         String formatted = String.format("%02d:%02d", hours, minutes);
         logFormatting("formatHHMM", ticks, formatted);
         return formatted;
@@ -29,10 +29,10 @@ public class TickTokFormatter {
 
     /** Format as "HH:mm:ss" */
     public static String formatHHMMSS(long ticks) {
-        int totalSeconds = (int)(ticks / TickTokHelper.TICKS_PER_SECOND);
-        int hours   = totalSeconds / 3600;
-        int minutes = (totalSeconds % 3600) / 60;
-        int seconds = totalSeconds % 60;
+        long totalSeconds = ticks / TickTokHelper.TICKS_PER_SECOND;
+        long hours   = totalSeconds / 3600;
+        long minutes = (totalSeconds % 3600) / 60;
+        long seconds = totalSeconds % 60;
         String formatted = String.format("%02d:%02d:%02d", hours, minutes, seconds);
         logFormatting("formatHHMMSS", ticks, formatted);
         return formatted;
@@ -40,11 +40,11 @@ public class TickTokFormatter {
 
     /** Format as "HH:mm:ss.SSS" */
     public static String formatHMSms(long ticks) {
-        int totalMs    = (int)(ticks * MS_PER_TICK);
-        int hours      = totalMs / 3_600_000;
-        int minutes    = (totalMs % 3_600_000) / 60_000;
-        int seconds    = (totalMs % 60_000) / 1000;
-        int millis     = totalMs % 1000;
+        long totalMs    = TickTokHelper.toMillisecondsLong(ticks);
+        long hours      = totalMs / 3_600_000;
+        long minutes    = (totalMs % 3_600_000) / 60_000;
+        long seconds    = (totalMs % 60_000) / 1000;
+        long millis     = totalMs % 1000;
         String formatted = String.format("%02d:%02d:%02d.%03d", hours, minutes, seconds, millis);
         logFormatting("formatHMSms", ticks, formatted);
         return formatted;

--- a/src/main/java/com/thunder/ticktoklib/TickTokHelper.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokHelper.java
@@ -78,7 +78,7 @@ public class TickTokHelper {
     }
 
     public static long toTicksMilliseconds(long milliseconds) {
-        long ticks = Math.round(milliseconds * (TICKS_PER_SECOND / 1000f));
+        long ticks = Math.round(milliseconds / (double) MS_PER_TICK);
         logConversion("toTicksMilliseconds", "milliseconds=" + milliseconds, ticks);
         return ticks;
     }

--- a/src/main/java/com/thunder/ticktoklib/TickTokLagFormatter.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokLagFormatter.java
@@ -36,7 +36,7 @@ public class TickTokLagFormatter {
     }
 
     private static void logFormatting(String methodName, long ticks, String formatted) {
-        if (TickTokConfig.isConversionTracingEnabled() && ModConstants.LOGGER.isTraceEnabled()) {
+        if (TickTokConfig.isFormattingTracingEnabled() && ModConstants.LOGGER.isTraceEnabled()) {
             ModConstants.LOGGER.trace("TickTokLagFormatter.{}(ticks={}) -> {}", methodName, ticks, formatted);
         }
     }

--- a/src/main/java/com/thunder/ticktoklib/util/SubTickScheduler.java
+++ b/src/main/java/com/thunder/ticktoklib/util/SubTickScheduler.java
@@ -1,0 +1,51 @@
+package com.thunder.ticktoklib.util;
+
+import com.thunder.ticktoklib.Core.ModConstants;
+import com.thunder.ticktoklib.TickTokConfig;
+import com.thunder.ticktoklib.TickTokHelper;
+import net.minecraft.server.MinecraftServer;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utility for scheduling tasks at fractions of a Minecraft tick using real time delays.
+ */
+public final class SubTickScheduler {
+    private SubTickScheduler() {
+    }
+
+    public static CompletableFuture<Void> scheduleHalfTick(Runnable task) {
+        return schedule(0.5, task);
+    }
+
+    public static CompletableFuture<Void> scheduleQuarterTick(Runnable task) {
+        return schedule(0.25, task);
+    }
+
+    public static CompletableFuture<Void> schedule(double ticks, Runnable task) {
+        Objects.requireNonNull(task, "task");
+        if (ticks < 0) {
+            throw new IllegalArgumentException("ticks must be >= 0");
+        }
+        long delayMillis = Math.round(ticks * TickTokHelper.MS_PER_TICK);
+        debug("schedule", ticks, delayMillis);
+        return CompletableFuture.runAsync(
+                task,
+                CompletableFuture.delayedExecutor(delayMillis, TimeUnit.MILLISECONDS)
+        );
+    }
+
+    public static CompletableFuture<Void> scheduleOnServer(double ticks, MinecraftServer server, Runnable task) {
+        Objects.requireNonNull(server, "server");
+        Objects.requireNonNull(task, "task");
+        return schedule(ticks, () -> server.execute(task));
+    }
+
+    private static void debug(String method, double ticks, long delayMillis) {
+        if (TickTokConfig.isDebugLoggingEnabled() && ModConstants.LOGGER.isDebugEnabled()) {
+            ModConstants.LOGGER.debug("SubTickScheduler.{} -> {} ticks ({} ms)", method, ticks, delayMillis);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Fix precision and potential overflow in tick<->millisecond conversions to avoid subtle rounding errors and integer overflow.
- Ensure formatting/log tracing uses the correct toggle so formatter trace logs are controllable.
- Provide a small utility to schedule work at fractional-tick delays (half/quarter ticks) for finer-grained timing needs.

### Description
- Change `TickTokHelper.toTicksMilliseconds(long)` to compute ticks via division by `MS_PER_TICK` for more accurate rounding and switched callers to use `toMillisecondsLong` where appropriate.
- Update `TickTokFormatter` to use `long` for `totalSeconds`, `hours`, `minutes`, `seconds` and compute `totalMs` via `TickTokHelper.toMillisecondsLong(ticks)` to avoid `int` overflow and improve accuracy in `formatHHMM`, `formatHHMMSS`, `formatHMSms`, and `formatLocalized`.
- Fix `TickTokLagFormatter` to use `TickTokConfig.isFormattingTracingEnabled()` for its trace logging condition so it follows the formatting tracing toggle.
- Add new `SubTickScheduler` utility at `src/main/java/com/thunder/ticktoklib/util/SubTickScheduler.java` with `scheduleHalfTick`, `scheduleQuarterTick`, `schedule(double, Runnable)`, and `scheduleOnServer` methods using `CompletableFuture.delayedExecutor` and `TickTokHelper.MS_PER_TICK`, plus debug logging tied to config.

### Testing
- No automated tests were run for these changes.
- Manual compilation was not reported in this rollout and no CI results are included.
- Consumers should run the project's normal build and unit tests to validate behavior after merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697baee7e3e883289131bf7d6e7f0de5)