### PR TITLE
Add moon phase helpers to TickTok API

### DIFF
--- a/src/main/java/com/thunder/ticktoklib/TickTokHelper.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokHelper.java
@@ -1,6 +1,7 @@
 package com.thunder.ticktoklib;
 
 import com.thunder.ticktoklib.Core.ModConstants;
+import com.thunder.ticktoklib.api.TickTokMoonPhase;
 import com.thunder.ticktoklib.api.TickTokPhase;
 import com.thunder.ticktoklib.util.TickTokTimerScheduler;
 import com.thunder.ticktoklib.util.TickTokTimeRange;
@@ -170,6 +171,19 @@ public class TickTokHelper {
         long clamped = Math.floorMod(dayTime, TickTokTimeRange.FULL_DAY);
         logConversion("clampToDay", "dayTime=" + dayTime, clamped);
         return clamped;
+    }
+
+    public static int moonPhaseIndex(long dayTime) {
+        long day = Math.floorDiv(dayTime, TickTokTimeRange.FULL_DAY);
+        int index = Math.floorMod(day, TickTokMoonPhase.values().length);
+        logConversion("moonPhaseIndex", "dayTime=" + dayTime, index);
+        return index;
+    }
+
+    public static TickTokMoonPhase resolveMoonPhase(long dayTime) {
+        TickTokMoonPhase phase = TickTokMoonPhase.fromIndex(moonPhaseIndex(dayTime));
+        logConversion("resolveMoonPhase", "dayTime=" + dayTime, phase);
+        return phase;
     }
 
     public static TickTokPhase resolvePhase(long dayTime) {

--- a/src/main/java/com/thunder/ticktoklib/api/TickTokAPI.java
+++ b/src/main/java/com/thunder/ticktoklib/api/TickTokAPI.java
@@ -255,6 +255,27 @@ public class TickTokAPI {
         return TickTokFormatter.formatLocalized(ticks, pattern, locale, zoneId);
     }
 
+    // ── Moon phase helpers ───────────────────────────────────────────
+    public static int moonPhaseIndex(long dayTime) {
+        logDelegation("moonPhaseIndex", "TickTokHelper.moonPhaseIndex", "dayTime=" + dayTime);
+        return TickTokHelper.moonPhaseIndex(dayTime);
+    }
+
+    public static int moonPhaseIndex(net.minecraft.world.level.Level level) {
+        logDelegation("moonPhaseIndex(level)", "TickTokHelper.moonPhaseIndex", "level=" + level.dimension().location());
+        return TickTokHelper.moonPhaseIndex(level.getDayTime());
+    }
+
+    public static TickTokMoonPhase currentMoonPhase(long dayTime) {
+        logDelegation("currentMoonPhase", "TickTokHelper.resolveMoonPhase", "dayTime=" + dayTime);
+        return TickTokHelper.resolveMoonPhase(dayTime);
+    }
+
+    public static TickTokMoonPhase currentMoonPhase(net.minecraft.world.level.Level level) {
+        logDelegation("currentMoonPhase(level)", "TickTokHelper.resolveMoonPhase", "level=" + level.dimension().location());
+        return TickTokHelper.resolveMoonPhase(level.getDayTime());
+    }
+
     // ── Phase helpers ────────────────────────────────────────────────
     public static TickTokPhase currentPhase(long dayTime) {
         logDelegation("currentPhase", "TickTokHelper.resolvePhase", "dayTime=" + dayTime);

--- a/src/main/java/com/thunder/ticktoklib/api/TickTokMoonPhase.java
+++ b/src/main/java/com/thunder/ticktoklib/api/TickTokMoonPhase.java
@@ -1,0 +1,28 @@
+package com.thunder.ticktoklib.api;
+
+public enum TickTokMoonPhase {
+    FULL_MOON(0),
+    WANING_GIBBOUS(1),
+    LAST_QUARTER(2),
+    WANING_CRESCENT(3),
+    NEW_MOON(4),
+    WAXING_CRESCENT(5),
+    FIRST_QUARTER(6),
+    WAXING_GIBBOUS(7);
+
+    private static final TickTokMoonPhase[] VALUES = values();
+    private final int index;
+
+    TickTokMoonPhase(int index) {
+        this.index = index;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public static TickTokMoonPhase fromIndex(int index) {
+        int normalized = Math.floorMod(index, VALUES.length);
+        return VALUES[normalized];
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple, stable moon-phase API so downstream mods (for example tides) can query the current moon phase or its numeric index from either a `dayTime` value or a `Level` instance.

### Description
- Add a `TickTokMoonPhase` enum that mirrors vanilla moon-phase ordering and exposes `getIndex()` and `fromIndex(int)` for interop with other mods (`src/main/java/com/thunder/ticktoklib/api/TickTokMoonPhase.java`).
- Add `TickTokHelper.moonPhaseIndex(long)` and `TickTokHelper.resolveMoonPhase(long)` to compute the moon-phase index and enum from an absolute `dayTime` (`TickTokHelper`).
- Expose API-level accessors `TickTokAPI.moonPhaseIndex(long)`, `TickTokAPI.moonPhaseIndex(Level)`, `TickTokAPI.currentMoonPhase(long)`, and `TickTokAPI.currentMoonPhase(Level)` so callers can obtain phase info from either a tick value or a `Level` (`TickTokAPI`).

### Testing
- No automated tests were executed as part of this change (no test suite run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c0867dcf883289ce81274a7b10ecd)