### PR TITLE
Add TickTokCooldown utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,33 @@ public abstract class WaterFluidMixin {
     }
 }
 ```
+
+Duration Formatting
+------------------
+TickTok now includes helpers for turning tick durations into short or long
+human-friendly strings:
+
+```java
+String compact = TickTokFormatter.formatDurationShort(1250); // "1m 2s 500ms"
+String verbose = TickTokFormatter.formatDurationLong(1250);  // "1 minute 2 seconds 500 milliseconds"
+```
+
+Need the raw breakdown instead? You can also pull a structured breakdown of ticks:
+
+```java
+TickTokDurationBreakdown breakdown = TickTokTimeUtils.breakdownTicks(1250);
+long seconds = breakdown.seconds();
+```
+
+Cooldown Utility
+---------------
+Need a simple reusable cooldown timer? The `TickTokCooldown` helper tracks a
+duration window and can format the remaining time:
+
+```java
+TickTokCooldown cooldown = new TickTokCooldown(200, level.getGameTime());
+if (cooldown.isReady(level.getGameTime())) {
+    cooldown.reset(level.getGameTime());
+}
+String remaining = cooldown.formatRemainingShort(level.getGameTime());
+```

--- a/src/main/java/com/thunder/ticktoklib/TickTokFormatter.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokFormatter.java
@@ -1,13 +1,12 @@
 package com.thunder.ticktoklib;
 
 import com.thunder.ticktoklib.Core.ModConstants;
+import com.thunder.ticktoklib.util.TickTokDurationBreakdown;
 
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
-
-import static com.thunder.ticktoklib.TickTokHelper.MS_PER_TICK;
 
 public class TickTokFormatter {
 
@@ -73,5 +72,57 @@ public class TickTokFormatter {
             pattern += ".SSS";
         }
         return formatLocalized(ticks, pattern, locale, ZoneId.systemDefault());
+    }
+
+    /**
+     * Format a tick duration as a short label (ex: "1h 2m 3s 450ms").
+     */
+    public static String formatDurationShort(long ticks) {
+        String formatted = formatDuration(ticks, true);
+        logFormatting("formatDurationShort", ticks, formatted);
+        return formatted;
+    }
+
+    /**
+     * Format a tick duration as a long label (ex: "1 hour 2 minutes 3 seconds 450 milliseconds").
+     */
+    public static String formatDurationLong(long ticks) {
+        String formatted = formatDuration(ticks, false);
+        logFormatting("formatDurationLong", ticks, formatted);
+        return formatted;
+    }
+
+    private static String formatDuration(long ticks, boolean shortUnits) {
+        TickTokDurationBreakdown breakdown = TickTokDurationBreakdown.fromTicks(ticks);
+        long hours = breakdown.hours();
+        long minutes = breakdown.minutes();
+        long seconds = breakdown.seconds();
+        long millis = breakdown.milliseconds();
+
+        StringBuilder builder = new StringBuilder();
+        appendDurationUnit(builder, hours, shortUnits ? "h" : "hour", shortUnits);
+        appendDurationUnit(builder, minutes, shortUnits ? "m" : "minute", shortUnits);
+        appendDurationUnit(builder, seconds, shortUnits ? "s" : "second", shortUnits);
+        if (millis > 0 || builder.length() == 0) {
+            appendDurationUnit(builder, millis, shortUnits ? "ms" : "millisecond", shortUnits);
+        }
+        return builder.toString();
+    }
+
+    private static void appendDurationUnit(StringBuilder builder, long value, String unit, boolean shortUnits) {
+        if (value == 0) {
+            return;
+        }
+        if (builder.length() > 0) {
+            builder.append(' ');
+        }
+        if (shortUnits) {
+            builder.append(value).append(unit);
+            return;
+        }
+        builder.append(value).append(' ').append(unit);
+        if (value != 1) {
+            builder.append('s');
+        }
     }
 }

--- a/src/main/java/com/thunder/ticktoklib/util/TickTokCooldown.java
+++ b/src/main/java/com/thunder/ticktoklib/util/TickTokCooldown.java
@@ -1,0 +1,51 @@
+package com.thunder.ticktoklib.util;
+
+import com.thunder.ticktoklib.TickTokFormatter;
+
+/**
+ * Utility for tracking a reusable cooldown window in ticks.
+ */
+public class TickTokCooldown {
+    private final long durationTicks;
+    private long startTick;
+
+    public TickTokCooldown(long durationTicks, long startTick) {
+        this.durationTicks = durationTicks;
+        this.startTick = startTick;
+    }
+
+    public long durationTicks() {
+        return durationTicks;
+    }
+
+    public void reset(long currentTick) {
+        this.startTick = currentTick;
+    }
+
+    public boolean isReady(long currentTick) {
+        return elapsedTicks(currentTick) >= durationTicks;
+    }
+
+    public long elapsedTicks(long currentTick) {
+        return Math.max(0, currentTick - startTick);
+    }
+
+    public long remainingTicks(long currentTick) {
+        return Math.max(0, durationTicks - elapsedTicks(currentTick));
+    }
+
+    public double remainingFraction(long currentTick) {
+        if (durationTicks <= 0) {
+            return 0;
+        }
+        return remainingTicks(currentTick) / (double) durationTicks;
+    }
+
+    public String formatRemainingShort(long currentTick) {
+        return TickTokFormatter.formatDurationShort(remainingTicks(currentTick));
+    }
+
+    public String formatRemainingLong(long currentTick) {
+        return TickTokFormatter.formatDurationLong(remainingTicks(currentTick));
+    }
+}

--- a/src/main/java/com/thunder/ticktoklib/util/TickTokDurationBreakdown.java
+++ b/src/main/java/com/thunder/ticktoklib/util/TickTokDurationBreakdown.java
@@ -1,0 +1,24 @@
+package com.thunder.ticktoklib.util;
+
+import com.thunder.ticktoklib.TickTokHelper;
+
+/**
+ * Represents a tick duration split into hour/minute/second/millisecond components.
+ */
+public record TickTokDurationBreakdown(
+        long hours,
+        long minutes,
+        long seconds,
+        long milliseconds,
+        long totalMilliseconds
+) {
+
+    public static TickTokDurationBreakdown fromTicks(long ticks) {
+        long totalMs = TickTokHelper.toMillisecondsLong(ticks);
+        long hours = totalMs / 3_600_000;
+        long minutes = (totalMs % 3_600_000) / 60_000;
+        long seconds = (totalMs % 60_000) / 1000;
+        long millis = totalMs % 1000;
+        return new TickTokDurationBreakdown(hours, minutes, seconds, millis, totalMs);
+    }
+}

--- a/src/main/java/com/thunder/ticktoklib/util/TickTokTimeUtils.java
+++ b/src/main/java/com/thunder/ticktoklib/util/TickTokTimeUtils.java
@@ -25,6 +25,13 @@ public final class TickTokTimeUtils {
         return Duration.ofMillis(millis);
     }
 
+    /** Break down ticks into hour/minute/second/millisecond components. */
+    public static TickTokDurationBreakdown breakdownTicks(long ticks) {
+        TickTokDurationBreakdown breakdown = TickTokDurationBreakdown.fromTicks(ticks);
+        debug("breakdownTicks", "ticks=" + ticks + " -> " + breakdown.totalMilliseconds() + "ms");
+        return breakdown;
+    }
+
     /** Convert ticks to a {@link Duration}, retaining the level for future time-scaling hooks. */
     public static Duration ticksToDuration(Level level, long ticks) {
         Objects.requireNonNull(level, "level");


### PR DESCRIPTION
### Motivation
- Provide a reusable, tick-based cooldown helper to avoid duplicating elapsed/remaining calculations in gameplay code.
- Make it easy to present remaining cooldown time using the existing duration formatters (`TickTokFormatter.formatDurationShort` / `formatDurationLong`).
- Complement the previously-introduced duration helpers (`TickTokDurationBreakdown` / `TickTokTimeUtils.breakdownTicks`) with a higher-level utility for common cooldown use-cases.

### Description
- Added `TickTokCooldown` in `com.thunder.ticktoklib.util` with `reset`, `isReady`, `elapsedTicks`, `remainingTicks`, `remainingFraction`, `formatRemainingShort`, and `formatRemainingLong` methods to manage a tick window and present remaining time.
- Updated `README.md` to document the `Cooldown Utility` usage with a short example using `TickTokCooldown` and formatter helpers.
- `TickTokCooldown` delegates human-readable formatting to the existing `TickTokFormatter` helpers and relies on the library's tick-to-millisecond conversions.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cc8aaf8d88328879e5c7d3b9dbe6d)