### PR TITLE
Add overload diagnostics to TickTok lag warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,14 @@ if (cooldown.isReady(level.getGameTime())) {
 }
 String remaining = cooldown.formatRemainingShort(level.getGameTime());
 ```
+
+Overload Diagnostics
+--------------------
+When Minecraft logs the "Can't keep up" warning, TickTok now appends a quick
+cause hint and, when detectable, a list of likely involved mod IDs.
+
+You can turn this off in config with:
+
+```toml
+enable_overload_diagnostics = true
+```

--- a/src/main/java/com/thunder/ticktoklib/TickTokConfig.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokConfig.java
@@ -16,6 +16,7 @@ public class TickTokConfig {
     public static final ModConfigSpec.BooleanValue ENABLE_TRACE_CONVERSIONS;
     public static final ModConfigSpec.BooleanValue ENABLE_TRACE_FORMATTING;
     public static final ModConfigSpec.BooleanValue ENABLE_TRACE_EVENTS;
+    public static final ModConfigSpec.BooleanValue ENABLE_OVERLOAD_DIAGNOSTICS;
 
     static {
         BUILDER.push("Tick Time Display Options");
@@ -55,6 +56,10 @@ public class TickTokConfig {
         ENABLE_TRACE_EVENTS = BUILDER
                 .comment("Emit TRACE logs for time-of-day phase events")
                 .define("enable_trace_events", false);
+
+        ENABLE_OVERLOAD_DIAGNOSTICS = BUILDER
+                .comment("Append suspected cause hints to server overload warnings")
+                .define("enable_overload_diagnostics", true);
 
         BUILDER.pop();
         SPEC = BUILDER.build();
@@ -97,6 +102,10 @@ public class TickTokConfig {
 
     public static boolean isEventTracingEnabled() {
         return safeGet(ENABLE_TRACE_EVENTS, false);
+    }
+
+    public static boolean isOverloadDiagnosticsEnabled() {
+        return safeGet(ENABLE_OVERLOAD_DIAGNOSTICS, true);
     }
 
     public static boolean showGameTime() {

--- a/src/main/java/com/thunder/ticktoklib/TickTokLagFormatter.java
+++ b/src/main/java/com/thunder/ticktoklib/TickTokLagFormatter.java
@@ -1,6 +1,7 @@
 package com.thunder.ticktoklib;
 
 import com.thunder.ticktoklib.Core.ModConstants;
+import com.thunder.ticktoklib.util.TickTokOverloadDiagnostics;
 import net.minecraft.network.chat.Component;
 
 /**
@@ -19,6 +20,11 @@ public class TickTokLagFormatter {
                 seconds,
                 millisecondsBehind
         );
+
+        if (TickTokConfig.isOverloadDiagnosticsEnabled()) {
+            formatted += " | " + TickTokOverloadDiagnostics.buildCauseHint(ticksBehind, millisecondsBehind);
+        }
+
         logFormatting("formatLagBehind", ticksBehind, formatted);
         return formatted;
     }

--- a/src/main/java/com/thunder/ticktoklib/util/TickTokOverloadDiagnostics.java
+++ b/src/main/java/com/thunder/ticktoklib/util/TickTokOverloadDiagnostics.java
@@ -1,0 +1,76 @@
+package com.thunder.ticktoklib.util;
+
+import net.neoforged.fml.ModList;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Lightweight heuristics for attaching "what might be causing this" hints to
+ * overload warnings.
+ */
+public class TickTokOverloadDiagnostics {
+
+    private static final Set<String> FRAME_PREFIX_BLOCKLIST = Set.of(
+            "java.",
+            "javax.",
+            "jdk.",
+            "sun.",
+            "org.slf4j.",
+            "org.apache.logging.",
+            "org.spongepowered.asm.",
+            "net.minecraft.",
+            "net.neoforged."
+    );
+
+    private TickTokOverloadDiagnostics() {
+    }
+
+    public static String buildCauseHint(long ticksBehind, long millisecondsBehind) {
+        Set<String> suspectedMods = detectSuspectedModsFromCurrentThread();
+        if (!suspectedMods.isEmpty()) {
+            return "Likely involved mod(s): " + String.join(", ", suspectedMods);
+        }
+
+        if (ticksBehind >= 200 || millisecondsBehind >= 10_000) {
+            return "Likely causes: chunk generation/loading spikes, heavy worldgen, or mass entity/block updates";
+        }
+
+        if (ticksBehind >= 40 || millisecondsBehind >= 2_000) {
+            return "Likely causes: temporary chunk loading bursts, autosaves, or scripted/modded tick spikes";
+        }
+
+        return "Likely causes: brief IO or tick scheduling spike";
+    }
+
+    private static Set<String> detectSuspectedModsFromCurrentThread() {
+        LinkedHashSet<String> hits = new LinkedHashSet<>();
+
+        StackTraceElement[] trace = Thread.currentThread().getStackTrace();
+        Arrays.stream(trace)
+                .map(StackTraceElement::getClassName)
+                .filter(TickTokOverloadDiagnostics::isCandidateClass)
+                .map(TickTokOverloadDiagnostics::toPotentialModId)
+                .filter(modId -> ModList.get().isLoaded(modId))
+                .limit(3)
+                .forEach(hits::add);
+
+        return hits;
+    }
+
+    private static boolean isCandidateClass(String className) {
+        for (String blockedPrefix : FRAME_PREFIX_BLOCKLIST) {
+            if (className.startsWith(blockedPrefix)) {
+                return false;
+            }
+        }
+
+        return className.contains(".");
+    }
+
+    private static String toPotentialModId(String className) {
+        String rootPackage = className.substring(0, className.indexOf('.'));
+        return rootPackage.toLowerCase();
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide more actionable information when Minecraft logs the "Can't keep up" server overload warning so server owners can quickly identify likely causes or offending mods.

### Description
- Append a human-readable cause hint to the lag message via `TickTokLagFormatter` when `enable_overload_diagnostics` is enabled.
- Add `TickTokOverloadDiagnostics`, a lightweight heuristic that inspects the current server thread stack to infer likely mod IDs and falls back to severity-based hints (chunk loading, worldgen, entity/block updates, IO/tick spikes).
- Add a configuration toggle `enable_overload_diagnostics` (default `true`) to `TickTokConfig` to allow disabling the appended hints.
- Document the new diagnostics behavior and the config key in `README.md`.

### Testing
- Ran `./gradlew compileJava` and the build completed successfully (BUILD SUCCESSFUL).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699899731e6c83289489f6a4c828aae6)