### PR TITLE
Harden TickTok timer scheduler execution and cleanup

### DIFF
--- a/src/main/java/com/thunder/ticktoklib/util/TickTokTimerScheduler.java
+++ b/src/main/java/com/thunder/ticktoklib/util/TickTokTimerScheduler.java
@@ -70,9 +70,13 @@ public class TickTokTimerScheduler {
         lastLevelTick.put(levelKey, currentTick);
         List<TimerTask> tasks = levelTasks.get(levelKey);
         if (tasks == null || tasks.isEmpty()) {
+            levelTasks.remove(levelKey, tasks);
             return;
         }
         tickTasks(tasks, currentTick, levelKey);
+        if (tasks.isEmpty()) {
+            levelTasks.remove(levelKey, tasks);
+        }
     }
 
     private TimerHandle scheduleEveryInternal(ResourceKey<Level> levelKey, long intervalTicks, Runnable task) {
@@ -116,7 +120,11 @@ public class TickTokTimerScheduler {
     }
 
     private void runTask(TimerTask task, long currentTick, ResourceKey<Level> levelKey) {
-        task.task.run();
+        try {
+            task.task.run();
+        } catch (Throwable throwable) {
+            ModConstants.LOGGER.error("TickTokTimerScheduler task failed for {}", levelKey == null ? "server" : levelKey.location(), throwable);
+        }
         long nextTick = task.nextTick;
         while (nextTick <= currentTick) {
             nextTick += task.intervalTicks;


### PR DESCRIPTION
### Motivation
- Prevent accumulation of stale per-level scheduler entries in `levelTasks` which can grow unbounded if empty lists remain after level unloads.
- Ensure a single buggy scheduled task cannot break the scheduler loop by catching and logging exceptions from task execution.

### Description
- Remove empty per-level task lists from `levelTasks` proactively in `onLevelTick` to keep the map clean and avoid stale entries (`src/main/java/com/thunder/ticktoklib/util/TickTokTimerScheduler.java`).
- Wrap `task.task.run()` in a `try/catch` inside `runTask` and log failures with level/server context using `ModConstants.LOGGER` to prevent exceptions from stopping scheduler processing.
- No public API changes; behavior changes are internal and focused on robustness and resource cleanup.

### Testing
- Ran `./gradlew test`, which completed successfully (BUILD SUCCESSFUL with `:test` reported as NO-SOURCE).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69989e7fbd5c8328a7eb8c64430357e0)