### PR TITLE
docs: add TickTok library/API wishlist and README link

### DIFF
--- a/API_WISHLIST.md
+++ b/API_WISHLIST.md
@@ -1,0 +1,57 @@
+# TickTok Library / API Wishlist
+
+For NeoForge mod development (Java + Gradle), these additions would make TickTok
+more production-friendly and easier to integrate across mods.
+
+## 1) Unified `ITickClock` abstraction
+- Add an interface for reading time from game tick, sub-tick, and wall-clock sources.
+- Include server/client-aware implementations.
+- Helps unit testing by allowing fake clocks.
+
+## 2) `TickTokTaskHandle` for cancellation and status
+- Return a lightweight handle from schedulers (`cancel()`, `isDone()`, `remainingTicks()`).
+- Include optional repeating tasks and fixed-rate/fixed-delay variants.
+
+## 3) Lifecycle-safe scheduler integration
+- Auto-cancel scheduled work on server stop, world unload, or player logout.
+- Optional owner-bound tasks (e.g., bound to a `UUID`, `Level`, or `ServerPlayer`).
+
+## 4) Event-driven timer callbacks
+- Add NeoForge event bridge helpers (e.g., once-after-N-ticks, each N ticks).
+- Expose a small DSL for common patterns:
+  - `every(20).ticks(...)`
+  - `after(5).seconds(...)`
+
+## 5) Serialization support
+- Built-in codecs/NBT serializers for cooldowns, countdowns, and phase trackers.
+- This makes persistence in capabilities/data attachments straightforward.
+
+## 6) Threading safety helpers
+- Dedicated APIs that guarantee execution on the main server thread.
+- Add guard methods to fail fast when called from the wrong thread.
+
+## 7) Metrics + debug introspection
+- Optional debug endpoint/log output listing active timers and queue size.
+- Useful for profiling lag spikes or memory leaks from forgotten tasks.
+
+## 8) Data-driven timing presets
+- Load common timer definitions from JSON resources.
+- Makes balancing easier without recompiling (great for pack/mod tuning).
+
+## 9) Kotlin-friendly API surface (optional)
+- Keep Java-first API, but provide null-safe builder/factory patterns that are pleasant in Kotlin mods.
+
+## 10) Testkit module
+- A tiny test utility package with fake clocks, deterministic scheduler stepping,
+  and assertion helpers for timer-driven code.
+
+---
+
+## Suggested rollout order
+1. `TaskHandle` + cancellation semantics
+2. Lifecycle-safe ownership and auto-cleanup
+3. Serialization codecs
+4. Debug/metrics
+5. Data-driven presets + testkit
+
+That order provides immediate safety/ergonomic wins while keeping migration risk low.

--- a/README.md
+++ b/README.md
@@ -106,3 +106,10 @@ You can turn this off in config with:
 ```toml
 enable_overload_diagnostics = true
 ```
+
+Library/API Roadmap Ideas
+-------------------------
+If you are planning next features, see [`API_WISHLIST.md`](API_WISHLIST.md) for
+recommended additions focused on NeoForge mod ergonomics, scheduling safety,
+and persistence support.
+


### PR DESCRIPTION
### Motivation
- Provide a discoverable roadmap of recommended TickTok library/API enhancements for NeoForge Java/Gradle mod development, emphasizing scheduling ergonomics, lifecycle safety, serialization, diagnostics, and testability.

### Description
- Add `API_WISHLIST.md` with ten prioritized suggestions (e.g., `ITickClock`, `TickTokTaskHandle`, lifecycle-safe schedulers, event-driven callbacks, serialization/NBT codecs, threading guards, metrics/debug introspection, data-driven presets, Kotlin-friendly bits, and a testkit) and add a "Library/API Roadmap Ideas" section to `README.md` linking to the new file.

### Testing
- Ran `./gradlew -q help`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69989e0148608328b128ffaf3a2dfa87)