### PR TITLE
Refactor phase tracking and timer scheduler; always handle phases each tick

### DIFF
--- a/src/main/java/com/thunder/ticktoklib/Core/TickTok.java
+++ b/src/main/java/com/thunder/ticktoklib/Core/TickTok.java
@@ -26,7 +26,6 @@ import net.neoforged.neoforge.event.tick.LevelTickEvent;
 
 public class TickTok {
 
-    private static final int TICK_OPTIMIZATION_INTERVAL = 20;
 
     private final TickTokPhaseTracker phaseTracker = new TickTokPhaseTracker();
 
@@ -118,13 +117,6 @@ public class TickTok {
     @SubscribeEvent
     public void onLevelTick(LevelTickEvent.Post event) {
         long dayTime = event.getLevel().getDayTime();
-
-        if (TickTokConfig.isTickOptimizationEnabled()) {
-            if (Math.floorMod(dayTime, TICK_OPTIMIZATION_INTERVAL) != 0) {
-                return;
-            }
-        }
-
         phaseTracker.handle(dayTime, event.getLevel().dimension());
     }
 }

--- a/src/main/java/com/thunder/ticktoklib/util/TickTokPhaseTracker.java
+++ b/src/main/java/com/thunder/ticktoklib/util/TickTokPhaseTracker.java
@@ -12,15 +12,15 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class TickTokPhaseTracker {
-    private final Map<ResourceKey<Level>, TickTokPhase> lastPhaseByLevel = new HashMap<>();
+    private final Map<ResourceKey<Level>, PhaseState> stateByLevel = new HashMap<>();
 
     public void handle(long dayTime, ResourceKey<Level> levelKey) {
         long clamped = Math.floorMod(dayTime, TickTokTimeRange.FULL_DAY);
-        TickTokPhase current = TickTokTimeRange.phaseFor(clamped);
-        TickTokPhase last = lastPhaseByLevel.get(levelKey);
+        PhaseState state = stateByLevel.get(levelKey);
 
-        if (last == null) {
-            lastPhaseByLevel.put(levelKey, current);
+        if (state == null) {
+            TickTokPhase current = TickTokTimeRange.phaseFor(clamped);
+            stateByLevel.put(levelKey, new PhaseState(current, nextBoundaryFor(current), clamped));
             if (TickTokConfig.isEventTracingEnabled() && ModConstants.LOGGER.isTraceEnabled()) {
                 ModConstants.LOGGER.trace("TickTokPhaseTracker initialized phase {} for {}", current, levelKey.location());
             }
@@ -28,13 +28,55 @@ public class TickTokPhaseTracker {
             return;
         }
 
-        if (last != current) {
-            NeoForge.EVENT_BUS.post(new TickTokPhaseEvent.End(last, clamped, levelKey));
+        if (!crossedBoundary(state.lastClampedTick, clamped, state.nextBoundaryTick)) {
+            state.lastClampedTick = clamped;
+            return;
+        }
+
+        TickTokPhase current = TickTokTimeRange.phaseFor(clamped);
+        if (state.phase != current) {
+            NeoForge.EVENT_BUS.post(new TickTokPhaseEvent.End(state.phase, clamped, levelKey));
             NeoForge.EVENT_BUS.post(new TickTokPhaseEvent.Start(current, clamped, levelKey));
-            lastPhaseByLevel.put(levelKey, current);
             if (TickTokConfig.isEventTracingEnabled() && ModConstants.LOGGER.isTraceEnabled()) {
-                ModConstants.LOGGER.trace("TickTokPhaseTracker transitioned {} -> {} for {} at {}", last, current, levelKey.location(), clamped);
+                ModConstants.LOGGER.trace("TickTokPhaseTracker transitioned {} -> {} for {} at {}", state.phase, current, levelKey.location(), clamped);
             }
+            state.phase = current;
+        }
+
+        state.nextBoundaryTick = nextBoundaryFor(state.phase);
+        state.lastClampedTick = clamped;
+    }
+
+    private static long nextBoundaryFor(TickTokPhase phase) {
+        return switch (phase) {
+            case DAY -> TickTokTimeRange.SUNSET_START;
+            case SUNSET -> TickTokTimeRange.NIGHT_START;
+            case NIGHT -> TickTokTimeRange.SUNRISE_START;
+            case SUNRISE -> TickTokTimeRange.DAY_START;
+        };
+    }
+
+    private static boolean crossedBoundary(long previousTick, long currentTick, long boundaryTick) {
+        if (previousTick == currentTick) {
+            return false;
+        }
+
+        if (previousTick < currentTick) {
+            return previousTick < boundaryTick && boundaryTick <= currentTick;
+        }
+
+        return previousTick < boundaryTick || boundaryTick <= currentTick;
+    }
+
+    private static final class PhaseState {
+        private TickTokPhase phase;
+        private long nextBoundaryTick;
+        private long lastClampedTick;
+
+        private PhaseState(TickTokPhase phase, long nextBoundaryTick, long lastClampedTick) {
+            this.phase = phase;
+            this.nextBoundaryTick = nextBoundaryTick;
+            this.lastClampedTick = lastClampedTick;
         }
     }
 }

--- a/src/main/java/com/thunder/ticktoklib/util/TickTokTimerScheduler.java
+++ b/src/main/java/com/thunder/ticktoklib/util/TickTokTimerScheduler.java
@@ -12,7 +12,6 @@ import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
@@ -87,7 +86,7 @@ public class TickTokTimerScheduler {
 
         long baseTick = levelKey == null
                 ? serverTickCounter.get()
-                : Optional.ofNullable(lastLevelTick.get(levelKey)).orElse(0L);
+                : lastLevelTick.getOrDefault(levelKey, 0L);
         long nextTick = baseTick + intervalTicks;
 
         TimerTask timerTask = new TimerTask(intervalTicks, nextTick, task);
@@ -108,14 +107,18 @@ public class TickTokTimerScheduler {
     }
 
     private void tickTasks(List<TimerTask> tasks, long currentTick, ResourceKey<Level> levelKey) {
+        boolean hasCancelled = false;
         for (TimerTask task : tasks) {
             if (task.isCancelled()) {
-                tasks.remove(task);
+                hasCancelled = true;
                 continue;
             }
             if (currentTick >= task.nextTick) {
                 runTask(task, currentTick, levelKey);
             }
+        }
+        if (hasCancelled) {
+            tasks.removeIf(TimerTask::isCancelled);
         }
     }
 
@@ -126,8 +129,10 @@ public class TickTokTimerScheduler {
             ModConstants.LOGGER.error("TickTokTimerScheduler task failed for {}", levelKey == null ? "server" : levelKey.location(), throwable);
         }
         long nextTick = task.nextTick;
-        while (nextTick <= currentTick) {
-            nextTick += task.intervalTicks;
+        if (nextTick <= currentTick) {
+            long interval = task.intervalTicks;
+            long missedIntervals = ((currentTick - nextTick) / interval) + 1;
+            nextTick += missedIntervals * interval;
         }
         task.nextTick = nextTick;
 


### PR DESCRIPTION
### Motivation

- Ensure accurate and timely phase transitions by calling phase handling on every tick instead of sampling every N ticks. 
- Fix edge cases in phase boundary detection (including day wrap-around) and reduce missed or duplicated scheduler executions. 
- Improve scheduler robustness and remove unnecessary optional handling and inefficient iteration patterns.

### Description

- Removed the tick sampling optimization by deleting `TICK_OPTIMIZATION_INTERVAL` and the early-return in `onLevelTick`, so `phaseTracker.handle` is invoked every tick. 
- Reworked `TickTokPhaseTracker` to use a `PhaseState` object per level storing the current `phase`, `nextBoundaryTick`, and `lastClampedTick`, added `nextBoundaryFor` and `crossedBoundary` helpers to correctly detect transitions across wrap-arounds, and emit `TickTokPhaseEvent.Start`/`End` events accordingly. 
- Improved `TickTokTimerScheduler` by replacing `Optional` usage with `getOrDefault`, deferring cancelled-task removals until after iteration to avoid concurrent modification, and replacing the `while` loop with arithmetic to compute missed intervals and advance `nextTick` efficiently. 
- Removed an unused import and added minor logging/initialization adjustments.

### Testing

- No automated tests were executed during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab7967ee6c83289368304473205ee1)